### PR TITLE
Add Fly.io deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy service
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Test and deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run unit tests
+        run: go test ./...
+
+      - name: Install Fly.io CLI
+        uses: superfly/flyctl-actions/setup-flyctl@v1
+
+      - name: Deploy to Fly.io
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_APP_NAME: ${{ secrets.FLY_APP_NAME }}
+        run: |
+          if [ -z "$FLY_API_TOKEN" ] || [ -z "$FLY_APP_NAME" ]; then
+            echo "FLY_API_TOKEN and FLY_APP_NAME secrets must be configured" >&2
+            exit 1
+          fi
+          flyctl deploy \
+            --config fly.toml \
+            --app "$FLY_APP_NAME" \
+            --remote-only

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.22 AS builder
+WORKDIR /src
+
+COPY go.mod ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o server ./...
+
+FROM gcr.io/distroless/base-debian12
+WORKDIR /app
+
+COPY --from=builder /src/server ./server
+EXPOSE 8080
+
+CMD ["./server"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,72 @@
 # golang-generic
+
+This repository contains a minimal HTTP service written in Go. The service exposes two endpoints:
+
+- `GET /` – returns a short JSON payload describing the service status.
+- `GET /healthz` – returns `204 No Content`, which is useful for health checks.
+
+## Getting started
+
+1. Ensure you have Go 1.21 or newer installed.
+2. Clone the repository and change into its directory.
+3. Run the service:
+
+```bash
+go run .
+```
+
+By default the server listens on port `8080`. Set the `PORT` environment variable to change the listen port, e.g. `PORT=9090 go run .`.
+
+### Testing the endpoints
+
+Once the server is running you can query it with `curl` or any HTTP client:
+
+```bash
+curl http://localhost:8080/
+# {"status":"ok","message":"golang-generic service is running"}
+
+curl -i http://localhost:8080/healthz
+# HTTP/1.1 204 No Content
+```
+
+## Deployment
+
+The development environment for this exercise does not provide a publicly accessible network endpoint, so the service cannot be hosted for external access from a web browser. However, the project is ready to be deployed anywhere Go applications can run (for example Fly.io, Render, Railway, or a small VM). Deploying it typically involves building the binary with `go build .` and running it on a server that exposes the chosen port to the internet.
+
+### Automated deployment with GitHub Actions (Fly.io)
+
+This repository includes a GitHub Actions workflow (`.github/workflows/deploy.yml`) and a Fly.io application definition (`fly.toml`) so you can automatically deploy the service to Fly.io from your own GitHub account.
+
+1. [Create a Fly.io account](https://fly.io) and install the `flyctl` CLI locally.
+2. Create a new Fly.io application for the service:
+
+   ```bash
+   flyctl apps create <your-app-name>
+   ```
+
+3. Update `fly.toml` and replace the placeholder `app` value (`golang-generic-placeholder`) with `<your-app-name>`.
+4. Generate a Fly.io access token and add it to your repository secrets as `FLY_API_TOKEN`:
+
+   ```bash
+   flyctl auth token
+   ```
+
+5. Add your Fly.io application name as the `FLY_APP_NAME` repository secret.
+6. Commit and push the changes (including the updated `fly.toml`) to GitHub.
+
+Every push to the `main` branch (or a manual “Run workflow” dispatch) will now:
+
+- check out the repository,
+- run `go test ./...`, and
+- deploy the latest version of the service to Fly.io using the Docker image defined in `Dockerfile`.
+
+If you prefer to deploy manually, you can run the same `flyctl deploy` command locally after logging in with `flyctl auth login`.
+
+### Container image
+
+The included `Dockerfile` builds a minimal Linux container image for the service. To build and run it locally:
+
+```bash
+docker build -t golang-generic .
+docker run --rm -p 8080:8080 golang-generic
+```

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,37 @@
+# Fly.io application configuration for the golang-generic service.
+# Update the "app" name to match your Fly.io application.
+
+app = "golang-generic-placeholder"
+primary_region = "iad"
+kill_signal = "SIGINT"
+kill_timeout = 5
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8080"
+
+[[services]]
+  processes = ["app"]
+  protocol = "tcp"
+  internal_port = 8080
+
+  [services.concurrency]
+    type = "connections"
+    hard_limit = 25
+    soft_limit = 20
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+  [[services.tcp_checks]]
+    interval = "15s"
+    timeout = "2s"
+    grace_period = "10s"
+    restart_limit = 0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module golang-generic
+
+go 1.21

--- a/main.go
+++ b/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+)
+
+type healthResponse struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+func main() {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		resp := healthResponse{
+			Status:  "ok",
+			Message: "golang-generic service is running",
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			log.Printf("failed to encode response: %v", err)
+		}
+	})
+
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	addr := ":" + port
+	log.Printf("starting server on %s", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatalf("server exited: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a Docker-based Fly.io configuration and deployment workflow for the Go service
- document the automated deployment setup and local container usage in the README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68cdd5a3cf988321bb65a932abaa6380