### PR TITLE
Adjust service1 default port to avoid Keycloak conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ FROM gcr.io/distroless/base-debian12
 WORKDIR /app
 
 COPY --from=builder /src/service1 ./service1
-EXPOSE 8080
+EXPOSE 8082
 
 CMD ["./service1"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Service1 is configured through environment variables:
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `PORT` | `8080` | Listen port. |
+| `PORT` | `8082` | Listen port. |
 | `S2_BASE_URL` | _(required for `/s2/secure-data`)_ | Base URL of service2, e.g. `http://localhost:8081`. |
 | `S2_BASIC_USER` | _(required)_ | Username for S2's Basic Auth endpoint. |
 | `S2_BASIC_PASSWORD` | _(required)_ | Password for S2's Basic Auth endpoint. |
@@ -49,7 +49,7 @@ valid token receive `401 Unauthorized`.
 For example, after obtaining an access token (see the [Keycloak realm container](#keycloak-realm-container) section below):
 
 ```bash
-curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/keycloak-greeting
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8082/keycloak-greeting
 ```
 
 ### Service2 (S2)
@@ -120,7 +120,7 @@ go run ./cmd/service1
 go run ./cmd/service2
 
 # Request proxied data
-curl http://localhost:8080/s2/secure-data
+curl http://localhost:8082/s2/secure-data
 ```
 
 S1 responds with a JSON document that includes the original payload returned by S2.
@@ -193,7 +193,7 @@ docker run --rm \
 
 # In another terminal configure S1 to reach S2 and Keycloak through Docker's network bridge
 docker run --rm \
-  -e PORT=8080 \
+  -e PORT=8082 \
   -e S2_BASE_URL=http://service2:8081 \
   -e S2_BASIC_USER=demo-user \
   -e S2_BASIC_PASSWORD=demo-pass \
@@ -201,7 +201,7 @@ docker run --rm \
   -e KEYCLOAK_CLIENT_ID=service-client \
   --link service2:service2 \
   --link keycloak:keycloak \
-  -p 8080:8080 service1
+  -p 8082:8082 service1
 ```
 
 > **Note:** This environment cannot host long-running services, but the images produced by the Dockerfiles are ready for deployment to your own infrastructure.

--- a/cmd/service1/main.go
+++ b/cmd/service1/main.go
@@ -107,7 +107,7 @@ func main() {
 
 	port := cfg.Port
 	if port == "" {
-		port = "8080"
+		port = "8082"
 	}
 
 	addr := ":" + port

--- a/fly.toml
+++ b/fly.toml
@@ -10,12 +10,12 @@ kill_timeout = 5
   dockerfile = "Dockerfile"
 
 [env]
-  PORT = "8080"
+  PORT = "8082"
 
 [[services]]
   processes = ["app"]
   protocol = "tcp"
-  internal_port = 8080
+  internal_port = 8082
 
   [services.concurrency]
     type = "connections"


### PR DESCRIPTION
## Summary
- change service1's default listening port and container exposure to 8082 so it no longer overlaps with Keycloak
- update documentation and Fly.io configuration to reflect the new service1 port

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d2dc5529088321b3da1013164b04f7