### PR TITLE
Accept Keycloak tokens with azp authorized party fallback

### DIFF
--- a/internal/keycloak/verifier.go
+++ b/internal/keycloak/verifier.go
@@ -42,6 +42,7 @@ type Claims struct {
 	Issuer            string   `json:"iss"`
 	Subject           string   `json:"sub"`
 	Audience          Audience `json:"aud"`
+	AuthorizedParty   string   `json:"azp"`
 	Expiry            int64    `json:"exp"`
 	IssuedAt          int64    `json:"iat"`
 	PreferredUsername string   `json:"preferred_username"`
@@ -148,8 +149,8 @@ func (v *Verifier) VerifyToken(ctx context.Context, token string) (*Claims, erro
 		return nil, errors.New("token has expired")
 	}
 
-	if !claims.Audience.Contains(v.clientID) {
-		return nil, fmt.Errorf("token audience does not contain %s", v.clientID)
+	if !claims.Audience.Contains(v.clientID) && claims.AuthorizedParty != v.clientID {
+		return nil, fmt.Errorf("token is not intended for client %s", v.clientID)
 	}
 
 	if claims.Issuer != v.issuer {


### PR DESCRIPTION
## Summary
- include the authorized party claim when parsing Keycloak JWTs
- fall back to the azp value when the audience does not list the configured client id

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d2ea154a9883219ae1246cad3652bf