### PR TITLE
Allow configuring Keycloak issuer aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Service1 is configured through environment variables:
 | `KEYCLOAK_ISSUER_URL` | _(required for `/keycloak-greeting`)_ | Issuer URL for the Keycloak realm, e.g. `http://localhost:8080/realms/demo`. |
 | `KEYCLOAK_CLIENT_ID` | _(required for `/keycloak-greeting`)_ | Client ID that must appear in the token audience claim. |
 | `KEYCLOAK_JWKS_URL` | `${KEYCLOAK_ISSUER_URL}/protocol/openid-connect/certs` | Optional override for the JWKS endpoint. |
+| `KEYCLOAK_ISSUER_ALIASES` | _(optional)_ | Comma-separated list of additional issuer URLs accepted during token validation. |
 
 Run S1 locally:
 
@@ -77,6 +78,7 @@ S2 validates RSA-signed JWTs issued by Keycloak. Provide the following environme
 | `KEYCLOAK_ISSUER_URL` | _(required)_ | Issuer URL for your Keycloak realm, e.g. `http://localhost:8080/realms/demo`. |
 | `KEYCLOAK_CLIENT_ID` | _(required)_ | Client ID configured in that realm. The token's audience must include this value. |
 | `KEYCLOAK_JWKS_URL` | `${KEYCLOAK_ISSUER_URL}/protocol/openid-connect/certs` | Optional override for the JWKS endpoint that exposes the signing keys. |
+| `KEYCLOAK_ISSUER_ALIASES` | _(optional)_ | Comma-separated list of additional issuer URLs accepted during token validation. |
 
 At startup the service downloads the JWKS set once and caches the RSA keys. Tokens are validated by checking:
 
@@ -88,6 +90,8 @@ At startup the service downloads the JWKS set once and caches the RSA keys. Toke
 The handler returns a JSON payload containing basic details such as the subject, audience, issuer, preferred username and token lifetime.
 
 > When using the bundled Keycloak container, set `KEYCLOAK_ISSUER_URL=http://localhost:8080/realms/demo` and `KEYCLOAK_CLIENT_ID=service-client`.
+
+If the URL used to obtain tokens differs from the one the services use to reach Keycloak (for example `http://localhost:8080/realms/demo` for token requests versus `http://keycloak:8080/realms/demo` inside a Docker network), supply the public value via `KEYCLOAK_ISSUER_ALIASES` so both issuers are trusted during validation.
 
 Run S2 locally:
 
@@ -186,6 +190,7 @@ docker run --rm -p 8080:8080 --name keycloak demo-keycloak
 docker run --rm \
   -e PORT=8081 \
   -e KEYCLOAK_ISSUER_URL=http://keycloak:8080/realms/demo \
+  -e KEYCLOAK_ISSUER_ALIASES=http://localhost:8080/realms/demo \
   -e KEYCLOAK_CLIENT_ID=service-client \
   -p 8081:8081 \
   --link keycloak:keycloak \
@@ -198,6 +203,7 @@ docker run --rm \
   -e S2_BASIC_USER=demo-user \
   -e S2_BASIC_PASSWORD=demo-pass \
   -e KEYCLOAK_ISSUER_URL=http://keycloak:8080/realms/demo \
+  -e KEYCLOAK_ISSUER_ALIASES=http://localhost:8080/realms/demo \
   -e KEYCLOAK_CLIENT_ID=service-client \
   --link service2:service2 \
   --link keycloak:keycloak \

--- a/internal/keycloak/verifier_test.go
+++ b/internal/keycloak/verifier_test.go
@@ -1,0 +1,76 @@
+package keycloak
+
+import "testing"
+
+func TestNormaliseIssuer(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "trim spaces and trailing slash",
+			input: "  http://example.com/realms/demo/  ",
+			want:  "http://example.com/realms/demo",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "leave without trailing slash",
+			input: "https://idp.example.com/realms/demo",
+			want:  "https://idp.example.com/realms/demo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normaliseIssuer(tt.input)
+			if got != tt.want {
+				t.Fatalf("normaliseIssuer(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerifierIsValidIssuer(t *testing.T) {
+	verifier := &Verifier{
+		validIssuer: map[string]struct{}{
+			"http://keycloak:8080/realms/demo":  {},
+			"http://localhost:8080/realms/demo": {},
+		},
+	}
+
+	cases := []struct {
+		name   string
+		issuer string
+		want   bool
+	}{
+		{
+			name:   "primary issuer",
+			issuer: "http://keycloak:8080/realms/demo",
+			want:   true,
+		},
+		{
+			name:   "alias issuer with whitespace and slash",
+			issuer: "  http://localhost:8080/realms/demo/  ",
+			want:   true,
+		},
+		{
+			name:   "unknown issuer",
+			issuer: "http://example.com/realms/demo",
+			want:   false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := verifier.isValidIssuer(tt.issuer)
+			if got != tt.want {
+				t.Fatalf("isValidIssuer(%q) = %t, want %t", tt.issuer, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add support for optional issuer aliases in the Keycloak verifier so tokens issued from alternate URLs are accepted
- expose KEYCLOAK_ISSUER_ALIASES configuration in service1 and service2 and document the setting in the README
- add unit tests covering issuer normalisation and alias checks

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d30016dc848321950e5c68d6b6cce1