### PR TITLE
Add Keycloak self-registration endpoint

### DIFF
--- a/cmd/service1/config_test.go
+++ b/cmd/service1/config_test.go
@@ -1,0 +1,40 @@
+package main
+
+import "testing"
+
+func TestParseKeycloakIssuer(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantBase  string
+		wantRealm string
+		wantErr   bool
+	}{
+		{name: "empty", input: "", wantBase: "", wantRealm: ""},
+		{name: "simple", input: "http://localhost:8080/realms/demo", wantBase: "http://localhost:8080", wantRealm: "demo"},
+		{name: "with prefix", input: "http://example.com/auth/realms/demo", wantBase: "http://example.com/auth", wantRealm: "demo"},
+		{name: "missing realm", input: "http://localhost:8080/realms/", wantErr: true},
+		{name: "no realms", input: "http://localhost:8080/foo", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			base, realm, err := parseKeycloakIssuer(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.input, err)
+			}
+			if base != tc.wantBase {
+				t.Fatalf("base = %q, want %q", base, tc.wantBase)
+			}
+			if realm != tc.wantRealm {
+				t.Fatalf("realm = %q, want %q", realm, tc.wantRealm)
+			}
+		})
+	}
+}

--- a/cmd/service1/register.go
+++ b/cmd/service1/register.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"golang-generic/internal/keycloak"
+)
+
+type registrationRequest struct {
+	Username string `json:"username"`
+	Email    string `json:"email,omitempty"`
+}
+
+type registrationResponse struct {
+	Service           string `json:"service"`
+	Message           string `json:"message"`
+	Username          string `json:"username"`
+	TemporaryPassword string `json:"temporary_password"`
+}
+
+func (s *server) handleKeycloakRegister(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if s.keycloakRegistrar == nil {
+		http.Error(w, "keycloak registration not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req registrationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON payload", http.StatusBadRequest)
+		return
+	}
+
+	username := strings.TrimSpace(req.Username)
+	if username == "" {
+		http.Error(w, "username is required", http.StatusBadRequest)
+		return
+	}
+
+	registration, err := s.keycloakRegistrar.RegisterUser(r.Context(), keycloak.RegistrationRequest{
+		Username: username,
+		Email:    strings.TrimSpace(req.Email),
+	})
+	if err != nil {
+		if errors.Is(err, keycloak.ErrUserAlreadyExists) {
+			http.Error(w, "user already exists", http.StatusConflict)
+			return
+		}
+		s.logger.Printf("failed to register user %q: %v", username, err)
+		http.Error(w, "failed to register user", http.StatusBadGateway)
+		return
+	}
+
+	s.logger.Printf("registered new Keycloak user %q with temporary password", registration.Username)
+
+	resp := registrationResponse{
+		Service:           "service1",
+		Message:           "user registered successfully",
+		Username:          registration.Username,
+		TemporaryPassword: registration.TemporaryPassword,
+	}
+	writeJSON(w, resp, http.StatusCreated)
+}

--- a/cmd/service1/register_test.go
+++ b/cmd/service1/register_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"golang-generic/internal/keycloak"
+)
+
+type fakeRegistrar struct {
+	registerFn func(ctx context.Context, req keycloak.RegistrationRequest) (*keycloak.RegistrationResult, error)
+}
+
+func (f fakeRegistrar) RegisterUser(ctx context.Context, req keycloak.RegistrationRequest) (*keycloak.RegistrationResult, error) {
+	if f.registerFn != nil {
+		return f.registerFn(ctx, req)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func TestHandleKeycloakRegisterSuccess(t *testing.T) {
+	var captured keycloak.RegistrationRequest
+	registrar := fakeRegistrar{registerFn: func(ctx context.Context, req keycloak.RegistrationRequest) (*keycloak.RegistrationResult, error) {
+		captured = req
+		return &keycloak.RegistrationResult{Username: req.Username, TemporaryPassword: "temp-pass"}, nil
+	}}
+
+	srv := &server{
+		logger:            log.New(io.Discard, "", 0),
+		keycloakRegistrar: registrar,
+	}
+
+	body, _ := json.Marshal(registrationRequest{Username: "new-user", Email: "user@example.com"})
+	req := httptest.NewRequest(http.MethodPost, "/keycloak-register", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	srv.handleKeycloakRegister(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", rec.Code)
+	}
+
+	if captured.Username != "new-user" {
+		t.Fatalf("expected username to be forwarded, got %q", captured.Username)
+	}
+
+	var resp registrationResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.TemporaryPassword != "temp-pass" {
+		t.Fatalf("unexpected password %q", resp.TemporaryPassword)
+	}
+}
+
+func TestHandleKeycloakRegisterUserExists(t *testing.T) {
+	registrar := fakeRegistrar{registerFn: func(ctx context.Context, req keycloak.RegistrationRequest) (*keycloak.RegistrationResult, error) {
+		return nil, keycloak.ErrUserAlreadyExists
+	}}
+	srv := &server{logger: log.New(io.Discard, "", 0), keycloakRegistrar: registrar}
+
+	req := httptest.NewRequest(http.MethodPost, "/keycloak-register", strings.NewReader(`{"username":"existing"}`))
+	rec := httptest.NewRecorder()
+	srv.handleKeycloakRegister(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected status 409, got %d", rec.Code)
+	}
+}
+
+func TestHandleKeycloakRegisterValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		body       string
+		wantStatus int
+	}{
+		{name: "wrong method", method: http.MethodGet, wantStatus: http.StatusMethodNotAllowed},
+		{name: "missing registrar", method: http.MethodPost, wantStatus: http.StatusServiceUnavailable},
+		{name: "invalid json", method: http.MethodPost, body: "{", wantStatus: http.StatusBadRequest},
+		{name: "missing username", method: http.MethodPost, body: `{"username":""}`, wantStatus: http.StatusBadRequest},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var registrar keycloak.UserRegistrar
+			if tc.name != "missing registrar" {
+				registrar = fakeRegistrar{}
+			}
+			srv := &server{logger: log.New(io.Discard, "", 0), keycloakRegistrar: registrar}
+
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(tc.method, "/keycloak-register", strings.NewReader(tc.body))
+			srv.handleKeycloakRegister(recorder, request)
+			if recorder.Code != tc.wantStatus {
+				t.Fatalf("expected status %d, got %d", tc.wantStatus, recorder.Code)
+			}
+		})
+	}
+}
+
+func TestHandleKeycloakRegisterFailure(t *testing.T) {
+	registrar := fakeRegistrar{registerFn: func(ctx context.Context, req keycloak.RegistrationRequest) (*keycloak.RegistrationResult, error) {
+		return nil, errors.New("boom")
+	}}
+	srv := &server{logger: log.New(io.Discard, "", 0), keycloakRegistrar: registrar}
+
+	req := httptest.NewRequest(http.MethodPost, "/keycloak-register", strings.NewReader(`{"username":"new"}`))
+	rec := httptest.NewRecorder()
+	srv.handleKeycloakRegister(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected status 502, got %d", rec.Code)
+	}
+}

--- a/internal/keycloak/admin.go
+++ b/internal/keycloak/admin.go
@@ -1,0 +1,405 @@
+package keycloak
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ErrUserAlreadyExists indicates that a Keycloak user with the requested username is already present.
+var ErrUserAlreadyExists = errors.New("keycloak: user already exists")
+
+// AdminConfig controls how the AdminClient communicates with Keycloak.
+type AdminConfig struct {
+	BaseURL          string
+	Realm            string
+	Username         string
+	Password         string
+	ClientID         string
+	RegistrationRole string
+	HTTPClient       *http.Client
+	PasswordLength   int
+}
+
+// RegistrationRequest represents the data used to create a new Keycloak user.
+type RegistrationRequest struct {
+	Username string
+	Email    string
+}
+
+// RegistrationResult describes the outcome of a successful registration.
+type RegistrationResult struct {
+	UserID            string
+	Username          string
+	TemporaryPassword string
+}
+
+// UserRegistrar allows registering new users in Keycloak.
+type UserRegistrar interface {
+	RegisterUser(ctx context.Context, req RegistrationRequest) (*RegistrationResult, error)
+}
+
+// AdminClient performs administrative operations against Keycloak's admin REST API.
+type AdminClient struct {
+	baseURL          string
+	realm            string
+	username         string
+	password         string
+	clientID         string
+	registrationRole string
+	httpClient       *http.Client
+	passwordLength   int
+
+	roleMu     sync.Mutex
+	cachedRole *roleRepresentation
+}
+
+type roleRepresentation struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+var defaultPasswordCharset = []rune("ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789@#$%")
+
+// NewAdminClient constructs an AdminClient using the supplied configuration.
+func NewAdminClient(cfg AdminConfig) (*AdminClient, error) {
+	baseURL := strings.TrimSpace(cfg.BaseURL)
+	if baseURL == "" {
+		return nil, errors.New("keycloak base URL must be provided")
+	}
+	if _, err := url.Parse(baseURL); err != nil {
+		return nil, fmt.Errorf("invalid keycloak base URL: %w", err)
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	realm := strings.TrimSpace(cfg.Realm)
+	if realm == "" {
+		return nil, errors.New("keycloak realm must be provided")
+	}
+
+	username := strings.TrimSpace(cfg.Username)
+	if username == "" {
+		return nil, errors.New("keycloak admin username must be provided")
+	}
+	password := cfg.Password
+	if password == "" {
+		return nil, errors.New("keycloak admin password must be provided")
+	}
+
+	registrationRole := strings.TrimSpace(cfg.RegistrationRole)
+	if registrationRole == "" {
+		return nil, errors.New("registration role must be provided")
+	}
+
+	clientID := strings.TrimSpace(cfg.ClientID)
+	if clientID == "" {
+		clientID = "admin-cli"
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 5 * time.Second}
+	}
+
+	passwordLength := cfg.PasswordLength
+	if passwordLength <= 0 {
+		passwordLength = 16
+	}
+
+	return &AdminClient{
+		baseURL:          baseURL,
+		realm:            realm,
+		username:         username,
+		password:         password,
+		clientID:         clientID,
+		registrationRole: registrationRole,
+		httpClient:       httpClient,
+		passwordLength:   passwordLength,
+	}, nil
+}
+
+// RegisterUser creates a Keycloak user with a temporary password and assigns the configured role.
+func (c *AdminClient) RegisterUser(ctx context.Context, req RegistrationRequest) (*RegistrationResult, error) {
+	username := strings.TrimSpace(req.Username)
+	if username == "" {
+		return nil, errors.New("username must be provided")
+	}
+
+	token, err := c.obtainToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	userID, err := c.createUser(ctx, token, username, strings.TrimSpace(req.Email))
+	if err != nil {
+		return nil, err
+	}
+
+	password, err := c.generatePassword()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.setTemporaryPassword(ctx, token, userID, password); err != nil {
+		return nil, err
+	}
+
+	if err := c.assignRole(ctx, token, userID); err != nil {
+		return nil, err
+	}
+
+	return &RegistrationResult{UserID: userID, Username: username, TemporaryPassword: password}, nil
+}
+
+func (c *AdminClient) obtainToken(ctx context.Context) (string, error) {
+	values := url.Values{}
+	values.Set("grant_type", "password")
+	values.Set("client_id", c.clientID)
+	values.Set("username", c.username)
+	values.Set("password", c.password)
+
+	endpoint := c.baseURL + "/realms/master/protocol/openid-connect/token"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(values.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := readBody(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token endpoint returned %s: %s", resp.Status, body)
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("parse token response: %w", err)
+	}
+	if tokenResp.AccessToken == "" {
+		return "", errors.New("token response missing access_token")
+	}
+	return tokenResp.AccessToken, nil
+}
+
+func (c *AdminClient) createUser(ctx context.Context, token, username, email string) (string, error) {
+	payload := map[string]any{
+		"username":        username,
+		"enabled":         true,
+		"requiredActions": []string{"UPDATE_PASSWORD"},
+	}
+	if email != "" {
+		payload["email"] = email
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal create user payload: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/admin/realms/%s/users", c.baseURL, c.realm)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("create user request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("create user: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := readBody(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode == http.StatusConflict {
+		return "", ErrUserAlreadyExists
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("create user returned %s: %s", resp.Status, respBody)
+	}
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		return "", errors.New("create user response missing Location header")
+	}
+
+	userID, err := extractUserID(location)
+	if err != nil {
+		return "", err
+	}
+	return userID, nil
+}
+
+func (c *AdminClient) setTemporaryPassword(ctx context.Context, token, userID, password string) error {
+	payload := map[string]any{
+		"type":      "password",
+		"value":     password,
+		"temporary": true,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal password payload: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/admin/realms/%s/users/%s/reset-password", c.baseURL, c.realm, userID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create password request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("set temporary password: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		respBody, _ := readBody(resp.Body)
+		return fmt.Errorf("set temporary password returned %s: %s", resp.Status, respBody)
+	}
+	return nil
+}
+
+func (c *AdminClient) assignRole(ctx context.Context, token, userID string) error {
+	role, err := c.fetchRole(ctx, token)
+	if err != nil {
+		return err
+	}
+
+	payload := []roleRepresentation{{ID: role.ID, Name: role.Name}}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal role assignment payload: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/admin/realms/%s/users/%s/role-mappings/realm", c.baseURL, c.realm, userID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create role assignment request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("assign role: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		respBody, _ := readBody(resp.Body)
+		return fmt.Errorf("assign role returned %s: %s", resp.Status, respBody)
+	}
+	return nil
+}
+
+func (c *AdminClient) fetchRole(ctx context.Context, token string) (*roleRepresentation, error) {
+	c.roleMu.Lock()
+	cached := c.cachedRole
+	c.roleMu.Unlock()
+	if cached != nil {
+		return cached, nil
+	}
+
+	endpoint := fmt.Sprintf("%s/admin/realms/%s/roles/%s", c.baseURL, c.realm, url.PathEscape(c.registrationRole))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create role lookup request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("lookup role: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := readBody(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("lookup role returned %s: %s", resp.Status, body)
+	}
+
+	var role roleRepresentation
+	if err := json.Unmarshal(body, &role); err != nil {
+		return nil, fmt.Errorf("parse role response: %w", err)
+	}
+	if role.ID == "" || role.Name == "" {
+		return nil, errors.New("role response missing id or name")
+	}
+
+	c.roleMu.Lock()
+	c.cachedRole = &role
+	c.roleMu.Unlock()
+
+	return &role, nil
+}
+
+func (c *AdminClient) generatePassword() (string, error) {
+	result := make([]rune, c.passwordLength)
+	charsetLength := big.NewInt(int64(len(defaultPasswordCharset)))
+	for i := range result {
+		idx, err := rand.Int(rand.Reader, charsetLength)
+		if err != nil {
+			return "", fmt.Errorf("generate password: %w", err)
+		}
+		result[i] = defaultPasswordCharset[idx.Int64()]
+	}
+	return string(result), nil
+}
+
+func extractUserID(location string) (string, error) {
+	parsed, err := url.Parse(location)
+	if err != nil {
+		return "", fmt.Errorf("invalid user location: %w", err)
+	}
+
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(segments) == 0 {
+		return "", errors.New("invalid user location path")
+	}
+
+	userID := segments[len(segments)-1]
+	if userID == "" {
+		return "", errors.New("user ID not found in location header")
+	}
+	return userID, nil
+}
+
+func readBody(body io.Reader) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+	return data, nil
+}

--- a/internal/keycloak/admin_test.go
+++ b/internal/keycloak/admin_test.go
@@ -1,0 +1,392 @@
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestAdminClientRegisterUser(t *testing.T) {
+	var createCalled atomic.Bool
+	var passwordSet string
+	var roleAssigned bool
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/realms/master/protocol/openid-connect/token":
+			if r.Method != http.MethodPost {
+				t.Fatalf("expected POST token request, got %s", r.Method)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("parse form: %v", err)
+			}
+			if got := r.PostForm.Get("client_id"); got != "admin-cli" {
+				t.Fatalf("unexpected client_id %q", got)
+			}
+			if got := r.PostForm.Get("username"); got != "admin" {
+				t.Fatalf("unexpected username %q", got)
+			}
+			if got := r.PostForm.Get("password"); got != "secret" {
+				t.Fatalf("unexpected password %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "test-token"})
+		case "/admin/realms/demo/users":
+			if r.Method != http.MethodPost {
+				t.Fatalf("expected POST create user, got %s", r.Method)
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
+				t.Fatalf("unexpected Authorization header %q", auth)
+			}
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode create user payload: %v", err)
+			}
+			if payload["username"] != "alice" {
+				t.Fatalf("unexpected username %v", payload["username"])
+			}
+			actions, ok := payload["requiredActions"].([]any)
+			if !ok || len(actions) != 1 || actions[0] != "UPDATE_PASSWORD" {
+				t.Fatalf("expected required action UPDATE_PASSWORD, got %#v", payload["requiredActions"])
+			}
+			createCalled.Store(true)
+			w.Header().Set("Location", server.URL+"/admin/realms/demo/users/12345")
+			w.WriteHeader(http.StatusCreated)
+		case "/admin/realms/demo/users/12345/reset-password":
+			if r.Method != http.MethodPut {
+				t.Fatalf("expected PUT reset password, got %s", r.Method)
+			}
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode password payload: %v", err)
+			}
+			if payload["temporary"] != true {
+				t.Fatalf("temporary flag not set: %#v", payload)
+			}
+			if value, ok := payload["value"].(string); ok {
+				passwordSet = value
+			}
+			w.WriteHeader(http.StatusNoContent)
+		case "/admin/realms/demo/roles/self-service-user":
+			if r.Method != http.MethodGet {
+				t.Fatalf("expected GET role lookup, got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(roleRepresentation{ID: "role-id", Name: "self-service-user"})
+		case "/admin/realms/demo/users/12345/role-mappings/realm":
+			if r.Method != http.MethodPost {
+				t.Fatalf("expected POST role mapping, got %s", r.Method)
+			}
+			var payload []roleRepresentation
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode role payload: %v", err)
+			}
+			if len(payload) != 1 || payload[0].ID != "role-id" {
+				t.Fatalf("unexpected role payload %#v", payload)
+			}
+			roleAssigned = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewAdminClient(AdminConfig{
+		BaseURL:          server.URL,
+		Realm:            "demo",
+		Username:         "admin",
+		Password:         "secret",
+		RegistrationRole: "self-service-user",
+	})
+	if err != nil {
+		t.Fatalf("NewAdminClient: %v", err)
+	}
+
+	res, err := client.RegisterUser(context.Background(), RegistrationRequest{Username: "alice"})
+	if err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+	if res.Username != "alice" {
+		t.Fatalf("unexpected username %q", res.Username)
+	}
+	if res.UserID != "12345" {
+		t.Fatalf("unexpected user ID %q", res.UserID)
+	}
+	if len(res.TemporaryPassword) == 0 {
+		t.Fatalf("temporary password not returned")
+	}
+	if !createCalled.Load() {
+		t.Fatalf("create user endpoint not called")
+	}
+	if passwordSet == "" {
+		t.Fatalf("password payload not observed")
+	}
+	if !roleAssigned {
+		t.Fatalf("role assignment not performed")
+	}
+}
+
+func TestAdminClientRegisterUser_UserExists(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/realms/master/protocol/openid-connect/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "test-token"})
+		case "/admin/realms/demo/users":
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"errorMessage":"exists"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewAdminClient(AdminConfig{
+		BaseURL:          server.URL,
+		Realm:            "demo",
+		Username:         "admin",
+		Password:         "secret",
+		RegistrationRole: "self-service-user",
+	})
+	if err != nil {
+		t.Fatalf("NewAdminClient: %v", err)
+	}
+
+	_, err = client.RegisterUser(context.Background(), RegistrationRequest{Username: "alice"})
+	if !errors.Is(err, ErrUserAlreadyExists) {
+		t.Fatalf("expected ErrUserAlreadyExists, got %v", err)
+	}
+}
+
+func TestExtractUserID(t *testing.T) {
+	tests := []struct {
+		location string
+		want     string
+		wantErr  bool
+	}{
+		{location: "/admin/realms/demo/users/123", want: "123"},
+		{location: "http://example.com/admin/realms/demo/users/abc", want: "abc"},
+		{location: "", wantErr: true},
+		{location: "not a url", want: "not a url"},
+		{location: "http://example.com/", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		got, err := extractUserID(tc.location)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("expected error for %q", tc.location)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("extractUserID(%q): %v", tc.location, err)
+		}
+		if got != tc.want {
+			t.Fatalf("extractUserID(%q) = %q, want %q", tc.location, got, tc.want)
+		}
+	}
+}
+
+func TestNewAdminClientValidation(t *testing.T) {
+	_, err := NewAdminClient(AdminConfig{})
+	if err == nil {
+		t.Fatalf("expected error when config empty")
+	}
+
+	_, err = NewAdminClient(AdminConfig{BaseURL: ":://invalid", Realm: "demo", Username: "u", Password: "p", RegistrationRole: "role"})
+	if err == nil {
+		t.Fatalf("expected error for invalid base URL")
+	}
+
+	client, err := NewAdminClient(AdminConfig{BaseURL: "http://example.com", Realm: "demo", Username: "u", Password: "p", RegistrationRole: "role"})
+	if err != nil {
+		t.Fatalf("NewAdminClient valid config: %v", err)
+	}
+	if got := client.passwordLength; got != 16 {
+		t.Fatalf("unexpected default password length %d", got)
+	}
+}
+
+func TestGeneratePasswordLength(t *testing.T) {
+	client, err := NewAdminClient(AdminConfig{BaseURL: "http://example.com", Realm: "demo", Username: "u", Password: "p", RegistrationRole: "role", PasswordLength: 20})
+	if err != nil {
+		t.Fatalf("NewAdminClient: %v", err)
+	}
+	pwd, err := client.generatePassword()
+	if err != nil {
+		t.Fatalf("generatePassword: %v", err)
+	}
+	if len(pwd) != 20 {
+		t.Fatalf("expected password length 20, got %d", len(pwd))
+	}
+}
+
+func TestReadBodyLimit(t *testing.T) {
+	data := strings.Repeat("a", 1024)
+	got, err := readBody(strings.NewReader(data))
+	if err != nil {
+		t.Fatalf("readBody: %v", err)
+	}
+	if string(got) != data {
+		t.Fatalf("unexpected body contents")
+	}
+}
+
+func TestFetchRoleCachesResult(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/realms/master/protocol/openid-connect/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "test-token"})
+		case "/admin/realms/demo/users":
+			w.Header().Set("Location", "/admin/realms/demo/users/1")
+			w.WriteHeader(http.StatusCreated)
+		case "/admin/realms/demo/users/1/reset-password":
+			w.WriteHeader(http.StatusNoContent)
+		case "/admin/realms/demo/roles/self-service-user":
+			atomic.AddInt32(&hits, 1)
+			_ = json.NewEncoder(w).Encode(roleRepresentation{ID: "role-id", Name: "self-service-user"})
+		case "/admin/realms/demo/users/1/role-mappings/realm":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewAdminClient(AdminConfig{
+		BaseURL:          server.URL,
+		Realm:            "demo",
+		Username:         "admin",
+		Password:         "secret",
+		RegistrationRole: "self-service-user",
+	})
+	if err != nil {
+		t.Fatalf("NewAdminClient: %v", err)
+	}
+
+	if _, err := client.RegisterUser(context.Background(), RegistrationRequest{Username: "alice"}); err != nil {
+		t.Fatalf("RegisterUser first call: %v", err)
+	}
+	if _, err := client.RegisterUser(context.Background(), RegistrationRequest{Username: "bob"}); err != nil {
+		t.Fatalf("RegisterUser second call: %v", err)
+	}
+
+	if hits != 1 {
+		t.Fatalf("expected role lookup to be cached, got %d hits", hits)
+	}
+}
+
+func TestCreateUserHandlesRelativeLocation(t *testing.T) {
+	// Regression test to ensure relative Location headers are accepted.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/realms/master/protocol/openid-connect/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "test-token"})
+		case "/admin/realms/demo/users":
+			w.Header().Set("Location", "/admin/realms/demo/users/789")
+			w.WriteHeader(http.StatusCreated)
+		case "/admin/realms/demo/users/789/reset-password":
+			w.WriteHeader(http.StatusNoContent)
+		case "/admin/realms/demo/roles/self-service-user":
+			_ = json.NewEncoder(w).Encode(roleRepresentation{ID: "role-id", Name: "self-service-user"})
+		case "/admin/realms/demo/users/789/role-mappings/realm":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewAdminClient(AdminConfig{
+		BaseURL:          server.URL,
+		Realm:            "demo",
+		Username:         "admin",
+		Password:         "secret",
+		RegistrationRole: "self-service-user",
+	})
+	if err != nil {
+		t.Fatalf("NewAdminClient: %v", err)
+	}
+
+	res, err := client.RegisterUser(context.Background(), RegistrationRequest{Username: "charlie"})
+	if err != nil {
+		t.Fatalf("RegisterUser: %v", err)
+	}
+	if res.UserID != "789" {
+		t.Fatalf("expected user ID 789, got %s", res.UserID)
+	}
+}
+
+func TestAssignRoleErrorPropagation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/realms/master/protocol/openid-connect/token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "test-token"})
+		case "/admin/realms/demo/users":
+			w.Header().Set("Location", "/admin/realms/demo/users/1")
+			w.WriteHeader(http.StatusCreated)
+		case "/admin/realms/demo/users/1/reset-password":
+			w.WriteHeader(http.StatusNoContent)
+		case "/admin/realms/demo/roles/self-service-user":
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewAdminClient(AdminConfig{
+		BaseURL:          server.URL,
+		Realm:            "demo",
+		Username:         "admin",
+		Password:         "secret",
+		RegistrationRole: "self-service-user",
+	})
+	if err != nil {
+		t.Fatalf("NewAdminClient: %v", err)
+	}
+
+	if _, err := client.RegisterUser(context.Background(), RegistrationRequest{Username: "alice"}); err == nil {
+		t.Fatalf("expected error when role lookup fails")
+	}
+}
+
+func TestObtainTokenError(t *testing.T) {
+	client, err := NewAdminClient(AdminConfig{BaseURL: "http://example.com", Realm: "demo", Username: "u", Password: "p", RegistrationRole: "role"})
+	if err != nil {
+		t.Fatalf("NewAdminClient: %v", err)
+	}
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("boom")
+	})}
+	if _, err := client.obtainToken(context.Background()); err == nil {
+		t.Fatalf("expected error when requesting token with invalid base URL")
+	}
+}
+
+func TestParseRoleURL(t *testing.T) {
+	client, err := NewAdminClient(AdminConfig{BaseURL: "http://example.com", Realm: "demo", Username: "u", Password: "p", RegistrationRole: "role"})
+	if err != nil {
+		t.Fatalf("NewAdminClient: %v", err)
+	}
+	endpoint := fmt.Sprintf("%s/admin/realms/%s/roles/%s", client.baseURL, client.realm, url.PathEscape(client.registrationRole))
+	if !strings.Contains(endpoint, "roles/role") {
+		t.Fatalf("role endpoint not formatted correctly: %s", endpoint)
+	}
+}

--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -37,6 +37,13 @@
         "composite": false,
         "clientRole": false,
         "containerId": "demo"
+      },
+      {
+        "name": "self-service-user",
+        "description": "Role granted to self-registered users",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "demo"
       }
     ],
     "client": {


### PR DESCRIPTION
## Summary
- add a Keycloak admin client and new /keycloak-register endpoint in service1
- generate temporary passwords, assign a predefined role, and document the flow
- expand the demo realm export with the self-service role and add thorough unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d315c113b08321b18b1ec4d4f2b85c