### PR TITLE
Implement SubjectCredentialManager for S2 adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Build artifacts for the Keycloak user storage example
+keycloak/user-storage-s2/target/

--- a/Dockerfile.keycloak
+++ b/Dockerfile.keycloak
@@ -1,8 +1,18 @@
+FROM maven:3.9.9-eclipse-temurin-21 AS s2-user-storage-build
+WORKDIR /build
+
+COPY keycloak/user-storage-s2/pom.xml ./
+RUN mvn -B dependency:go-offline
+
+COPY keycloak/user-storage-s2/src ./src
+RUN mvn -B package
+
 FROM quay.io/keycloak/keycloak:23.0
 
 ENV KEYCLOAK_ADMIN=admin \
     KEYCLOAK_ADMIN_PASSWORD=admin
 
+COPY --from=s2-user-storage-build /build/target/s2-user-storage-1.0-SNAPSHOT.jar /opt/keycloak/providers/
 COPY keycloak/realm-export.json /opt/keycloak/data/import/realm-export.json
 
 RUN /opt/keycloak/bin/kc.sh build

--- a/README.md
+++ b/README.md
@@ -163,6 +163,33 @@ export KEYCLOAK_ISSUER_URL=http://localhost:8080/realms/demo
 export KEYCLOAK_CLIENT_ID=service-client
 ```
 
+### User Storage SPI example
+
+The Keycloak container image now bundles a custom **User Storage SPI** provider that delegates password checks to Service2's
+Basic Auth endpoint. The provider is packaged from the Maven project under `keycloak/user-storage-s2` and copied into Keycloak
+at build time.
+
+When the realm import runs, a new component named **Service2 Basic Auth** is created. The component accepts three configuration
+properties:
+
+| Property | Description | Default |
+| --- | --- | --- |
+| `s2BaseUrl` | Base URL used to contact Service2. | `http://service2:8081` |
+| `s2Endpoint` | Relative path of the Basic Auth protected endpoint. | `/secure-data` |
+| `s2TimeoutMillis` | Timeout (in milliseconds) for validation requests. | `2000` |
+
+To test the integration locally:
+
+1. Start Service2 so it is reachable by Keycloak. When running Keycloak via Docker, place both containers on the same network
+   and keep Service2 available as `http://service2:8081` or adjust the component configuration in the Keycloak admin console.
+2. Build and run the Keycloak image with `docker build -f Dockerfile.keycloak -t demo-keycloak .` followed by
+   `docker run --rm -p 8080:8080 --name keycloak demo-keycloak`.
+3. Authenticate against Keycloak with the Service2 Basic Auth credentials, e.g. obtain a token using
+   `demo-user` / `demo-pass` as the username and password.
+
+During authentication Keycloak issues a Basic Auth request to Service2's secure endpoint. A `200 OK` response marks the
+credentials as valid while other responses (or timeouts) reject the login attempt.
+
 The JWKS endpoint is automatically derived from the issuer but can be overridden via `KEYCLOAK_JWKS_URL` if required.
 
 ## Containerization

--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -91,6 +91,29 @@
       ]
     }
   ],
+  "components": {
+    "org.keycloak.storage.UserStorageProvider": [
+      {
+        "id": "s2-user-storage-demo",
+        "name": "Service2 Basic Auth",
+        "providerId": "s2-user-storage",
+        "providerType": "org.keycloak.storage.UserStorageProvider",
+        "parentId": "demo",
+        "subComponents": {},
+        "config": {
+          "s2BaseUrl": [
+            "http://service2:8081"
+          ],
+          "s2Endpoint": [
+            "/secure-data"
+          ],
+          "s2TimeoutMillis": [
+            "2000"
+          ]
+        }
+      }
+    ]
+  },
   "clientScopes": [
 	  {
   "name": "offline_access",

--- a/keycloak/user-storage-s2/pom.xml
+++ b/keycloak/user-storage-s2/pom.xml
@@ -1,0 +1,68 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.keycloak</groupId>
+    <artifactId>s2-user-storage</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <keycloak.version>23.0.0</keycloak.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi-private</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-model-legacy</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.5.0.Final</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>21</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Built-By>golang-generic</Built-By>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserAdapter.java
+++ b/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserAdapter.java
@@ -1,0 +1,207 @@
+package com.example.keycloak.s2;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.component.ComponentModel;
+import org.keycloak.credential.CredentialInput;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.SubjectCredentialManager;
+import org.keycloak.models.UserModel;
+import org.keycloak.storage.StorageId;
+import org.keycloak.storage.adapter.AbstractUserAdapter;
+
+/**
+ * Minimal user adapter that exposes Service2 users to Keycloak.
+ */
+class S2UserAdapter extends AbstractUserAdapter.Streams {
+
+    private final String id;
+    private final String username;
+    private final S2UserStorageProvider provider;
+    private final SubjectCredentialManager credentialManager;
+    private final Map<String, List<String>> attributes = new HashMap<>();
+
+    S2UserAdapter(KeycloakSession session, RealmModel realm, ComponentModel model, S2UserStorageProvider provider, String username) {
+        super(session, realm, model);
+        this.username = username;
+        this.provider = provider;
+        this.id = StorageId.keycloakId(model, username);
+        this.credentialManager = new S2SubjectCredentialManager();
+        attributes.put(UserModel.USERNAME, Collections.singletonList(username));
+        attributes.put(UserModel.EMAIL, Collections.singletonList(username + "@service2.local"));
+        attributes.put(UserModel.FIRST_NAME, Collections.singletonList("Service2"));
+        attributes.put(UserModel.LAST_NAME, Collections.singletonList("User"));
+    }
+
+    @Override
+    public SubjectCredentialManager credentialManager() {
+        return credentialManager;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public void setUsername(String username) {
+        throw new UnsupportedOperationException("Read only user");
+    }
+
+    @Override
+    public String getEmail() {
+        return attributes.getOrDefault(UserModel.EMAIL, List.of()).stream().findFirst().orElse(null);
+    }
+
+    @Override
+    public void setEmail(String email) {
+        throw new UnsupportedOperationException("Read only user");
+    }
+
+    @Override
+    public String getFirstName() {
+        return attributes.getOrDefault(UserModel.FIRST_NAME, List.of()).stream().findFirst().orElse(null);
+    }
+
+    @Override
+    public void setFirstName(String firstName) {
+        throw new UnsupportedOperationException("Read only user");
+    }
+
+    @Override
+    public String getLastName() {
+        return attributes.getOrDefault(UserModel.LAST_NAME, List.of()).stream().findFirst().orElse(null);
+    }
+
+    @Override
+    public void setLastName(String lastName) {
+        throw new UnsupportedOperationException("Read only user");
+    }
+
+    @Override
+    public Map<String, List<String>> getAttributes() {
+        return Collections.unmodifiableMap(attributes);
+    }
+
+    @Override
+    public Stream<String> getAttributeStream(String name) {
+        return attributes.getOrDefault(name, List.of()).stream();
+    }
+
+    @Override
+    public void setAttribute(String name, List<String> values) {
+        throw new UnsupportedOperationException("Read only user");
+    }
+
+    @Override
+    public void setSingleAttribute(String name, String value) {
+        throw new UnsupportedOperationException("Read only user");
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        throw new UnsupportedOperationException("Read only user");
+    }
+
+    private class S2SubjectCredentialManager implements SubjectCredentialManager {
+
+        @Override
+        public boolean isValid(List<CredentialInput> inputs) {
+            if (inputs == null || inputs.isEmpty()) {
+                return false;
+            }
+            return inputs.stream().allMatch(input -> provider.isValid(realm, S2UserAdapter.this, input));
+        }
+
+        @Override
+        public boolean updateCredential(CredentialInput input) {
+            throw new UnsupportedOperationException("Read only user");
+        }
+
+        @Override
+        public void updateStoredCredential(CredentialModel cred) {
+            throw new UnsupportedOperationException("Read only user");
+        }
+
+        @Override
+        public CredentialModel createStoredCredential(CredentialModel cred) {
+            throw new UnsupportedOperationException("Read only user");
+        }
+
+        @Override
+        public boolean removeStoredCredentialById(String id) {
+            throw new UnsupportedOperationException("Read only user");
+        }
+
+        @Override
+        public CredentialModel getStoredCredentialById(String id) {
+            return null;
+        }
+
+        @Override
+        public Stream<CredentialModel> getStoredCredentialsStream() {
+            return Stream.empty();
+        }
+
+        @Override
+        public Stream<CredentialModel> getStoredCredentialsByTypeStream(String type) {
+            return Stream.empty();
+        }
+
+        @Override
+        public CredentialModel getStoredCredentialByNameAndType(String name, String type) {
+            return null;
+        }
+
+        @Override
+        public boolean moveStoredCredentialTo(String id, String newPreviousCredentialId) {
+            throw new UnsupportedOperationException("Read only user");
+        }
+
+        @Override
+        public void updateCredentialLabel(String credentialId, String credentialLabel) {
+            throw new UnsupportedOperationException("Read only user");
+        }
+
+        @Override
+        public void disableCredentialType(String credentialType) {
+            throw new UnsupportedOperationException("Read only user");
+        }
+
+        @Override
+        public Stream<String> getDisableableCredentialTypesStream() {
+            return Stream.empty();
+        }
+
+        @Override
+        public boolean isConfiguredFor(String type) {
+            return provider.isConfiguredFor(realm, S2UserAdapter.this, type);
+        }
+
+        @Override
+        public boolean isConfiguredLocally(String type) {
+            return isConfiguredFor(type);
+        }
+
+        @Override
+        public Stream<String> getConfiguredUserStorageCredentialTypesStream() {
+            return Stream.empty();
+        }
+
+        @Override
+        public CredentialModel createCredentialThroughProvider(CredentialModel model) {
+            throw new UnsupportedOperationException("Read only user");
+        }
+    }
+}

--- a/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProvider.java
+++ b/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProvider.java
@@ -1,0 +1,147 @@
+package com.example.keycloak.s2;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Objects;
+
+import org.jboss.logging.Logger;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.credential.CredentialInput;
+import org.keycloak.credential.CredentialInputValidator;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.storage.StorageId;
+import org.keycloak.storage.UserStorageProvider;
+import org.keycloak.storage.user.UserLookupProvider;
+
+/**
+ * Delegates password validation to Service2 by issuing a Basic Auth request against its secure endpoint.
+ */
+public class S2UserStorageProvider implements UserStorageProvider, UserLookupProvider, CredentialInputValidator {
+
+    private static final Logger LOGGER = Logger.getLogger(S2UserStorageProvider.class);
+    private static final String PASSWORD_CREDENTIAL_TYPE = "password";
+
+    private final KeycloakSession session;
+    private final ComponentModel model;
+    private final HttpClient httpClient;
+    private final URI secureEndpoint;
+    private final Duration timeout;
+
+    public S2UserStorageProvider(KeycloakSession session, ComponentModel model, URI secureEndpoint, Duration timeout) {
+        this.session = session;
+        this.model = model;
+        this.secureEndpoint = secureEndpoint;
+        this.timeout = timeout;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(timeout)
+                .build();
+    }
+
+    @Override
+    public void close() {
+        // Nothing to close
+    }
+
+    @Override
+    public UserModel getUserById(RealmModel realm, String id) {
+        StorageId storageId = new StorageId(id);
+        String externalId = storageId.getExternalId();
+        if (externalId == null) {
+            return null;
+        }
+        return createAdapter(realm, externalId);
+    }
+
+    @Override
+    public UserModel getUserByUsername(RealmModel realm, String username) {
+        if (username == null || username.trim().isEmpty()) {
+            return null;
+        }
+        return createAdapter(realm, username.trim());
+    }
+
+    @Override
+    public UserModel getUserByEmail(RealmModel realm, String email) {
+        if (email == null) {
+            return null;
+        }
+        String trimmed = email.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        String username = trimmed.contains("@") ? trimmed.substring(0, trimmed.indexOf('@')) : trimmed;
+        return createAdapter(realm, username);
+    }
+
+    @Override
+    public boolean supportsCredentialType(String credentialType) {
+        return Objects.equals(credentialType, PASSWORD_CREDENTIAL_TYPE);
+    }
+
+    @Override
+    public boolean isConfiguredFor(RealmModel realm, UserModel user, String credentialType) {
+        return supportsCredentialType(credentialType);
+    }
+
+    @Override
+    public boolean isValid(RealmModel realm, UserModel user, CredentialInput credentialInput) {
+        if (!supportsCredentialType(credentialInput.getType())) {
+            return false;
+        }
+        String username = user.getUsername();
+        String password = credentialInput.getChallengeResponse();
+        if (password == null) {
+            return false;
+        }
+        return validateAgainstService(username, password);
+    }
+
+    private UserModel createAdapter(RealmModel realm, String username) {
+        LOGGER.debugf("Creating adapter for username %s", username);
+        return new S2UserAdapter(session, realm, model, this, username);
+    }
+
+    private boolean validateAgainstService(String username, String password) {
+        LOGGER.debugf("Validating credentials for %s using Service2", username);
+        HttpRequest request = HttpRequest.newBuilder(secureEndpoint)
+                .timeout(timeout)
+                .header("Authorization", buildBasicAuth(username, password))
+                .GET()
+                .build();
+        try {
+            HttpResponse<Void> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+            int status = response.statusCode();
+            if (status == 200) {
+                LOGGER.debugf("Service2 accepted credentials for %s", username);
+                return true;
+            }
+            if (status == 401) {
+                LOGGER.debugf("Service2 rejected credentials for %s", username);
+                return false;
+            }
+            LOGGER.warnf("Unexpected status %d while validating %s via Service2", status, username);
+            return false;
+        } catch (IOException e) {
+            LOGGER.errorf(e, "IO error while validating %s against Service2", username);
+            return false;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.warnf(e, "Request interrupted while validating %s", username);
+            return false;
+        }
+    }
+
+    private static String buildBasicAuth(String username, String password) {
+        String token = username + ":" + password;
+        String encoded = Base64.getEncoder().encodeToString(token.getBytes(StandardCharsets.UTF_8));
+        return "Basic " + encoded;
+    }
+}

--- a/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProviderFactory.java
+++ b/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProviderFactory.java
@@ -1,0 +1,121 @@
+package com.example.keycloak.s2;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.logging.Logger;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.storage.UserStorageProviderFactory;
+
+/**
+ * Factory that creates {@link S2UserStorageProvider} instances.
+ */
+public class S2UserStorageProviderFactory implements UserStorageProviderFactory<S2UserStorageProvider> {
+
+    public static final String PROVIDER_ID = "s2-user-storage";
+
+    static final String CONFIG_BASE_URL = "s2BaseUrl";
+    static final String CONFIG_ENDPOINT = "s2Endpoint";
+    static final String CONFIG_TIMEOUT = "s2TimeoutMillis";
+
+    private static final Logger LOGGER = Logger.getLogger(S2UserStorageProviderFactory.class);
+
+    private static final ProviderConfigProperty BASE_URL = new ProviderConfigProperty(
+            CONFIG_BASE_URL,
+            "Service base URL",
+            "Base URL for Service2. The provider calls its Basic Auth endpoint to validate credentials.",
+            ProviderConfigProperty.STRING_TYPE,
+            "http://service2:8081"
+    );
+
+    private static final ProviderConfigProperty ENDPOINT = new ProviderConfigProperty(
+            CONFIG_ENDPOINT,
+            "Secure endpoint path",
+            "Relative path that requires HTTP Basic authentication on Service2.",
+            ProviderConfigProperty.STRING_TYPE,
+            "/secure-data"
+    );
+
+    private static final ProviderConfigProperty TIMEOUT = new ProviderConfigProperty(
+            CONFIG_TIMEOUT,
+            "Request timeout (ms)",
+            "Timeout in milliseconds when contacting Service2.",
+            ProviderConfigProperty.STRING_TYPE,
+            "2000"
+    );
+
+    @Override
+    public S2UserStorageProvider create(KeycloakSession session, ComponentModel model) {
+        String baseUrl = model.getConfig().getFirst(CONFIG_BASE_URL);
+        String endpoint = model.getConfig().getFirst(CONFIG_ENDPOINT);
+        String timeoutRaw = model.getConfig().getFirst(CONFIG_TIMEOUT);
+
+        URI targetEndpoint = resolveEndpoint(baseUrl, endpoint);
+        Duration timeout = parseTimeout(timeoutRaw);
+
+        LOGGER.debugf("Creating S2 user storage provider with endpoint %s and timeout %s", targetEndpoint, timeout);
+        return new S2UserStorageProvider(session, model, targetEndpoint, timeout);
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        List<ProviderConfigProperty> properties = new ArrayList<>();
+        properties.add(BASE_URL);
+        properties.add(ENDPOINT);
+        properties.add(TIMEOUT);
+        return properties;
+    }
+
+    private static URI resolveEndpoint(String baseUrl, String endpoint) {
+        String effectiveBase = baseUrl != null ? baseUrl.trim() : "";
+        if (effectiveBase.isEmpty()) {
+            effectiveBase = defaultValue(BASE_URL);
+        }
+
+        String effectiveEndpoint = endpoint != null ? endpoint.trim() : "";
+        if (effectiveEndpoint.isEmpty()) {
+            effectiveEndpoint = defaultValue(ENDPOINT);
+        }
+
+        String normalisedEndpoint = effectiveEndpoint.startsWith("/") ? effectiveEndpoint : "/" + effectiveEndpoint;
+
+        try {
+            URI baseUri = new URI(effectiveBase);
+            return baseUri.resolve(normalisedEndpoint);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid Service2 URL configuration", e);
+        }
+    }
+
+    private static Duration parseTimeout(String timeoutRaw) {
+        String value = timeoutRaw != null ? timeoutRaw.trim() : "";
+        if (value.isEmpty()) {
+            value = defaultValue(TIMEOUT);
+        }
+
+        try {
+            long millis = Long.parseLong(value);
+            if (millis <= 0) {
+                throw new IllegalArgumentException("Timeout must be positive");
+            }
+            return Duration.ofMillis(millis);
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("Timeout must be a number", ex);
+        }
+    }
+
+    private static String defaultValue(ProviderConfigProperty property) {
+        Object value = property.getDefaultValue();
+        return value != null ? value.toString() : "";
+    }
+}

--- a/keycloak/user-storage-s2/src/main/resources/META-INF/services/org.keycloak.storage.UserStorageProviderFactory
+++ b/keycloak/user-storage-s2/src/main/resources/META-INF/services/org.keycloak.storage.UserStorageProviderFactory
@@ -1,0 +1,1 @@
+com.example.keycloak.s2.S2UserStorageProviderFactory


### PR DESCRIPTION
## Summary
- replace the adapter's use of the removed CredentialManager API with an embedded SubjectCredentialManager that delegates validation back to the provider for Keycloak 23 compatibility
- pass the storage provider instance into each adapter so the credential manager can reuse the existing credential validation logic

## Testing
- go test ./...
- mvn -B -f keycloak/user-storage-s2/pom.xml package

------
https://chatgpt.com/codex/tasks/task_e_68d310f88a748321a7527d23db78bc6c