### PR TITLE
Fix Keycloak provider build for Java 17 compatibility

### DIFF
--- a/Dockerfile.keycloak
+++ b/Dockerfile.keycloak
@@ -1,4 +1,4 @@
-FROM maven:3.9.9-eclipse-temurin-21 AS s2-user-storage-build
+FROM maven:3.9.9-eclipse-temurin-17 AS s2-user-storage-build
 WORKDIR /build
 
 COPY keycloak/user-storage-s2/pom.xml ./

--- a/keycloak/user-storage-s2/pom.xml
+++ b/keycloak/user-storage-s2/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <keycloak.version>23.0.0</keycloak.version>
     </properties>
 
@@ -48,7 +48,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>21</release>
+                    <release>17</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Summary
- target Java 17 when building the custom Keycloak user storage provider
- build the provider in Docker with a Java 17 Maven image to match the Keycloak runtime

## Testing
- mvn -f keycloak/user-storage-s2/pom.xml -B package *(fails: unable to reach Maven Central from the environment)*
- docker build -f Dockerfile.keycloak . *(fails: `docker` command not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b16019748321ae8f7f5af00da832