### PR TITLE
Remove providerType from Keycloak realm export

### DIFF
--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -97,8 +97,6 @@
         "id": "s2-user-storage-demo",
         "name": "Service2 Basic Auth",
         "providerId": "s2-user-storage",
-        "providerType": "org.keycloak.storage.UserStorageProvider",
-        "parentId": "demo",
         "subComponents": {},
         "config": {
           "s2BaseUrl": [


### PR DESCRIPTION
## Summary
- remove the providerType and parentId properties from the custom user storage component definition in the realm export to match the current Keycloak import schema

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3b2f1097083218ff3b56273f61625