### PR TITLE
Add Keycloak authorization code flow endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Both services are written in Go and are ready to be built into separate containe
 | `GET /healthz` | Returns `204 No Content` for health checking. |
 | `GET /s2/secure-data` | Invokes the secure endpoint on S2 using the configured Basic Auth credentials and returns the upstream response alongside S1 metadata. |
 | `GET /keycloak-greeting` | Requires a Keycloak Bearer token and returns a greeting payload containing token details. |
+| `GET /keycloak/login` | Initiates the Keycloak Authorization Code flow (uses PKCE) and redirects the caller to Keycloak. |
+| `GET /keycloak/callback` | Handles the OAuth callback, exchanges the code for tokens, and returns the received payload plus decoded claims. |
 
 #### Configuration
 
@@ -34,6 +36,8 @@ Service1 is configured through environment variables:
 | `KEYCLOAK_CLIENT_ID` | _(required for `/keycloak-greeting`)_ | Client ID that must appear in the token audience claim. |
 | `KEYCLOAK_JWKS_URL` | `${KEYCLOAK_ISSUER_URL}/protocol/openid-connect/certs` | Optional override for the JWKS endpoint. |
 | `KEYCLOAK_ISSUER_ALIASES` | _(optional)_ | Comma-separated list of additional issuer URLs accepted during token validation. |
+| `KEYCLOAK_REDIRECT_URL` | _(required for `/keycloak/login`)_ | Redirect URI registered for the client. Must point to `http(s)://<host>/keycloak/callback`. |
+| `KEYCLOAK_SCOPES` | `openid,profile,email` | Optional list of scopes requested during the Authorization Code flow. Separate with commas or spaces. |
 
 Run S1 locally:
 
@@ -46,6 +50,12 @@ go run ./cmd/service1
 If the Keycloak environment variables are supplied, Service1 exposes `GET /keycloak-greeting`. The handler validates the Bearer
 token, then returns a JSON document containing the subject, preferred username, token lifetime and audience. Requests without a
 valid token receive `401 Unauthorized`.
+
+When the redirect configuration variables are provided, Service1 can also orchestrate the Keycloak Authorization Code flow.
+Visiting `/keycloak/login` generates a PKCE code challenge, stores the verifier on the server, and redirects the user to the
+Keycloak login form. After a successful login Keycloak invokes `/keycloak/callback`, where Service1 exchanges the code for tokens
+and (if the verifier is configured) validates the resulting access token before returning the raw token response alongside the
+decoded claims.
 
 For example, after obtaining an access token (see the [Keycloak realm container](#keycloak-realm-container) section below):
 
@@ -60,7 +70,9 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8082/keycloak-greeting
 | `GET /` | None | Returns status information for S2. |
 | `GET /healthz` | None | Returns `204 No Content`. |
 | `GET /secure-data` | HTTP Basic (`demo-user` / `demo-pass`) | Returns a JSON payload with sample protected data. |
-| `GET /keycloak-data` | Bearer token (Keycloak) | Validates a Keycloak JWT and echoes selected claims.
+| `GET /keycloak-data` | Bearer token (Keycloak) | Validates a Keycloak JWT and echoes selected claims. |
+| `GET /keycloak/login` | None | Initiates the Authorization Code flow and redirects the caller to Keycloak with PKCE parameters. |
+| `GET /keycloak/callback` | None | Handles the Keycloak OAuth callback, swaps the code for tokens, and returns them with decoded access token claims. |
 
 #### Basic authentication
 
@@ -79,6 +91,8 @@ S2 validates RSA-signed JWTs issued by Keycloak. Provide the following environme
 | `KEYCLOAK_CLIENT_ID` | _(required)_ | Client ID configured in that realm. The token's audience must include this value. |
 | `KEYCLOAK_JWKS_URL` | `${KEYCLOAK_ISSUER_URL}/protocol/openid-connect/certs` | Optional override for the JWKS endpoint that exposes the signing keys. |
 | `KEYCLOAK_ISSUER_ALIASES` | _(optional)_ | Comma-separated list of additional issuer URLs accepted during token validation. |
+| `KEYCLOAK_REDIRECT_URL` | _(required for `/keycloak/login`)_ | Redirect URI registered for the client (e.g. `http://localhost:8081/keycloak/callback`). |
+| `KEYCLOAK_SCOPES` | `openid,profile,email` | Optional list of scopes requested when redirecting to Keycloak. |
 
 At startup the service downloads the JWKS set once and caches the RSA keys. Tokens are validated by checking:
 
@@ -88,6 +102,8 @@ At startup the service downloads the JWKS set once and caches the RSA keys. Toke
 - the token has not expired.
 
 The handler returns a JSON payload containing basic details such as the subject, audience, issuer, preferred username and token lifetime.
+
+With the redirect variables configured, Service2 also exposes `/keycloak/login` and `/keycloak/callback` to perform the Authorization Code flow. The login endpoint issues a PKCE challenge and redirects to Keycloak, while the callback swaps the code for tokens and verifies the resulting access token (when the verifier is enabled) before returning the raw response and decoded claims.
 
 > When using the bundled Keycloak container, set `KEYCLOAK_ISSUER_URL=http://localhost:8080/realms/demo` and `KEYCLOAK_CLIENT_ID=service-client`.
 

--- a/cmd/service1/main.go
+++ b/cmd/service1/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"golang-generic/internal/keycloak"
@@ -43,6 +47,27 @@ type keycloakGreetingResponse struct {
 	ExpiresAt         string   `json:"expires_at"`
 }
 
+type keycloakAuthResponse struct {
+	Service            string       `json:"service"`
+	Message            string       `json:"message"`
+	AccessToken        string       `json:"access_token"`
+	IDToken            string       `json:"id_token,omitempty"`
+	RefreshToken       string       `json:"refresh_token,omitempty"`
+	TokenType          string       `json:"token_type,omitempty"`
+	Scope              string       `json:"scope,omitempty"`
+	ExpiresIn          int          `json:"expires_in,omitempty"`
+	AccessTokenDetails *tokenClaims `json:"access_token_claims,omitempty"`
+}
+
+type tokenClaims struct {
+	Subject           string   `json:"subject"`
+	PreferredUsername string   `json:"preferred_username,omitempty"`
+	Audience          []string `json:"audience"`
+	Issuer            string   `json:"issuer"`
+	IssuedAt          string   `json:"issued_at,omitempty"`
+	ExpiresAt         string   `json:"expires_at,omitempty"`
+}
+
 type config struct {
 	Port                  string
 	S2BaseURL             string
@@ -54,12 +79,16 @@ type config struct {
 	KeycloakClientID      string
 	KeycloakJWKSURL       string
 	KeycloakIssuerAliases []string
+	KeycloakRedirectURL   string
+	KeycloakScopes        []string
 }
 
 type server struct {
 	logger           *log.Logger
 	s2Client         *s2Client
 	keycloakVerifier *keycloak.Verifier
+	oauthClient      *keycloak.OAuthClient
+	authStates       *stateStore
 }
 
 func main() {
@@ -95,17 +124,42 @@ func main() {
 		logger.Printf("Keycloak configuration not set; /keycloak-greeting endpoint will be disabled")
 	}
 
+	var oauthClient *keycloak.OAuthClient
+	var authStates *stateStore
+	if cfg.KeycloakIssuerURL != "" && cfg.KeycloakClientID != "" && cfg.KeycloakRedirectURL != "" {
+		var err error
+		oauthClient, err = keycloak.NewOAuthClient(keycloak.OAuthConfig{
+			IssuerURL:   cfg.KeycloakIssuerURL,
+			ClientID:    cfg.KeycloakClientID,
+			RedirectURL: cfg.KeycloakRedirectURL,
+			Scopes:      cfg.KeycloakScopes,
+			HTTPClient:  &http.Client{Timeout: 5 * time.Second},
+		})
+		if err != nil {
+			logger.Printf("unable to configure Keycloak OAuth client: %v", err)
+		} else {
+			authStates = newStateStore(authStateTTL)
+			logger.Printf("Keycloak OAuth client initialised; redirect URI %s", cfg.KeycloakRedirectURL)
+		}
+	} else {
+		logger.Printf("Keycloak OAuth configuration not set; /keycloak/login endpoint will be disabled")
+	}
+
 	mux := http.NewServeMux()
 	srv := &server{
 		logger:           logger,
 		s2Client:         client,
 		keycloakVerifier: keycloakVerifier,
+		oauthClient:      oauthClient,
+		authStates:       authStates,
 	}
 
 	mux.HandleFunc("/", srv.handleIndex)
 	mux.HandleFunc("/healthz", srv.handleHealthz)
 	mux.HandleFunc("/s2/secure-data", srv.handleS2SecureData)
 	mux.HandleFunc("/keycloak-greeting", srv.handleKeycloakGreeting)
+	mux.HandleFunc("/keycloak/login", srv.handleKeycloakLogin)
+	mux.HandleFunc("/keycloak/callback", srv.handleKeycloakCallback)
 
 	port := cfg.Port
 	if port == "" {
@@ -133,6 +187,11 @@ func loadConfig() config {
 		jwksURL = strings.TrimSuffix(issuer, "/") + "/protocol/openid-connect/certs"
 	}
 
+	scopes := parseScopeList(os.Getenv("KEYCLOAK_SCOPES"))
+	if len(scopes) == 0 {
+		scopes = []string{"openid", "profile", "email"}
+	}
+
 	return config{
 		Port:                  strings.TrimSpace(os.Getenv("PORT")),
 		S2BaseURL:             strings.TrimSpace(os.Getenv("S2_BASE_URL")),
@@ -144,6 +203,8 @@ func loadConfig() config {
 		KeycloakClientID:      strings.TrimSpace(os.Getenv("KEYCLOAK_CLIENT_ID")),
 		KeycloakJWKSURL:       jwksURL,
 		KeycloakIssuerAliases: parseEnvList(os.Getenv("KEYCLOAK_ISSUER_ALIASES")),
+		KeycloakRedirectURL:   strings.TrimSpace(os.Getenv("KEYCLOAK_REDIRECT_URL")),
+		KeycloakScopes:        scopes,
 	}
 }
 
@@ -165,6 +226,36 @@ func parseEnvList(raw string) []string {
 		return nil
 	}
 	return values
+}
+
+func parseScopeList(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		switch r {
+		case ',', ' ', '\t':
+			return true
+		default:
+			return false
+		}
+	})
+
+	scopes := make([]string, 0, len(fields))
+	for _, scope := range fields {
+		trimmed := strings.TrimSpace(scope)
+		if trimmed != "" {
+			scopes = append(scopes, trimmed)
+		}
+	}
+
+	if len(scopes) == 0 {
+		return nil
+	}
+
+	return scopes
 }
 
 func (s *server) handleIndex(w http.ResponseWriter, r *http.Request) {
@@ -270,6 +361,104 @@ func (s *server) handleKeycloakGreeting(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, resp, http.StatusOK)
 }
 
+func (s *server) handleKeycloakLogin(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if s.oauthClient == nil || s.authStates == nil {
+		http.Error(w, "keycloak oauth not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	state, err := generateState()
+	if err != nil {
+		s.logger.Printf("failed to generate oauth state: %v", err)
+		http.Error(w, "failed to initiate login", http.StatusInternalServerError)
+		return
+	}
+
+	codeVerifier, err := generateCodeVerifier()
+	if err != nil {
+		s.logger.Printf("failed to generate code verifier: %v", err)
+		http.Error(w, "failed to initiate login", http.StatusInternalServerError)
+		return
+	}
+	codeChallenge := codeChallengeFromVerifier(codeVerifier)
+
+	authURL, err := s.oauthClient.AuthCodeURL(state, codeChallenge)
+	if err != nil {
+		s.logger.Printf("failed to build auth URL: %v", err)
+		http.Error(w, "failed to initiate login", http.StatusInternalServerError)
+		return
+	}
+
+	s.authStates.store(state, codeVerifier)
+	s.logger.Printf("redirecting user to Keycloak auth endpoint")
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+func (s *server) handleKeycloakCallback(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if s.oauthClient == nil || s.authStates == nil {
+		http.Error(w, "keycloak oauth not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	state := strings.TrimSpace(r.URL.Query().Get("state"))
+	code := strings.TrimSpace(r.URL.Query().Get("code"))
+	if state == "" || code == "" {
+		http.Error(w, "state and code are required", http.StatusBadRequest)
+		return
+	}
+
+	codeVerifier, ok := s.authStates.consume(state)
+	if !ok {
+		http.Error(w, "invalid or expired state", http.StatusBadRequest)
+		return
+	}
+
+	tokenResp, err := s.oauthClient.Exchange(r.Context(), code, codeVerifier)
+	if err != nil {
+		s.logger.Printf("token exchange failed: %v", err)
+		http.Error(w, "failed to exchange code", http.StatusBadGateway)
+		return
+	}
+
+	response := keycloakAuthResponse{
+		Service:      "service1",
+		Message:      "authorization code exchanged successfully",
+		AccessToken:  tokenResp.AccessToken,
+		IDToken:      tokenResp.IDToken,
+		RefreshToken: tokenResp.RefreshToken,
+		TokenType:    tokenResp.TokenType,
+		Scope:        tokenResp.Scope,
+		ExpiresIn:    tokenResp.ExpiresIn,
+	}
+
+	if s.keycloakVerifier != nil && tokenResp.AccessToken != "" {
+		if claims, err := s.keycloakVerifier.VerifyToken(r.Context(), tokenResp.AccessToken); err != nil {
+			s.logger.Printf("access token verification failed: %v", err)
+		} else {
+			response.AccessTokenDetails = &tokenClaims{
+				Subject:           claims.Subject,
+				PreferredUsername: claims.PreferredUsername,
+				Audience:          []string(claims.Audience),
+				Issuer:            claims.Issuer,
+				IssuedAt:          formatUnixTime(claims.IssuedAt),
+				ExpiresAt:         formatUnixTime(claims.Expiry),
+			}
+		}
+	}
+
+	writeJSON(w, response, http.StatusOK)
+}
+
 func writeJSON(w http.ResponseWriter, payload any, statusCode int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
@@ -324,6 +513,84 @@ func (lrw *loggingResponseWriter) Write(p []byte) (int, error) {
 	n, err := lrw.ResponseWriter.Write(p)
 	lrw.bytesWritten += int64(n)
 	return n, err
+}
+
+const authStateTTL = 5 * time.Minute
+
+type stateStore struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	entries map[string]stateEntry
+}
+
+type stateEntry struct {
+	codeVerifier string
+	expiresAt    time.Time
+}
+
+func newStateStore(ttl time.Duration) *stateStore {
+	if ttl <= 0 {
+		ttl = authStateTTL
+	}
+	return &stateStore{
+		ttl:     ttl,
+		entries: make(map[string]stateEntry),
+	}
+}
+
+func (s *stateStore) store(state, codeVerifier string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.entries[state] = stateEntry{
+		codeVerifier: codeVerifier,
+		expiresAt:    time.Now().Add(s.ttl),
+	}
+}
+
+func (s *stateStore) consume(state string) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.entries[state]
+	if !ok {
+		return "", false
+	}
+	delete(s.entries, state)
+
+	if time.Now().After(entry.expiresAt) {
+		return "", false
+	}
+
+	return entry.codeVerifier, true
+}
+
+func generateCodeVerifier() (string, error) {
+	return randomString(32)
+}
+
+func generateState() (string, error) {
+	return randomString(24)
+}
+
+func randomString(bytes int) (string, error) {
+	buf := make([]byte, bytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("failed to read random bytes: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func codeChallengeFromVerifier(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func formatUnixTime(ts int64) string {
+	if ts == 0 {
+		return ""
+	}
+	return time.Unix(ts, 0).UTC().Format(time.RFC3339)
 }
 
 type s2Client struct {

--- a/cmd/service2/main.go
+++ b/cmd/service2/main.go
@@ -1,14 +1,18 @@
 package main
 
 import (
-	"crypto/subtle"
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"golang-generic/internal/keycloak"
@@ -17,6 +21,8 @@ import (
 type service struct {
 	logger        *log.Logger
 	tokenVerifier *keycloak.Verifier
+	oauthClient   *keycloak.OAuthClient
+	authStates    *stateStore
 }
 
 type keycloakConfig struct {
@@ -24,6 +30,8 @@ type keycloakConfig struct {
 	ClientID      string
 	JWKSURL       string
 	IssuerAliases []string
+	RedirectURL   string
+	Scopes        []string
 }
 
 type secureDataResponse struct {
@@ -43,6 +51,27 @@ type keycloakDataResponse struct {
 	ExpiresAt         string   `json:"expires_at"`
 }
 
+type keycloakAuthResponse struct {
+	Service            string       `json:"service"`
+	Message            string       `json:"message"`
+	AccessToken        string       `json:"access_token"`
+	IDToken            string       `json:"id_token,omitempty"`
+	RefreshToken       string       `json:"refresh_token,omitempty"`
+	TokenType          string       `json:"token_type,omitempty"`
+	Scope              string       `json:"scope,omitempty"`
+	ExpiresIn          int          `json:"expires_in,omitempty"`
+	AccessTokenDetails *tokenClaims `json:"access_token_claims,omitempty"`
+}
+
+type tokenClaims struct {
+	Subject           string   `json:"subject"`
+	PreferredUsername string   `json:"preferred_username,omitempty"`
+	Audience          []string `json:"audience"`
+	Issuer            string   `json:"issuer"`
+	IssuedAt          string   `json:"issued_at,omitempty"`
+	ExpiresAt         string   `json:"expires_at,omitempty"`
+}
+
 func main() {
 	logger := log.New(os.Stdout, "[service2] ", log.LstdFlags)
 	cfg := loadKeycloakConfig()
@@ -54,13 +83,35 @@ func main() {
 		logger.Printf("keycloak verifier initialised for issuer %s", cfg.IssuerURL)
 	}
 
-	srv := &service{logger: logger, tokenVerifier: verifier}
+	var oauthClient *keycloak.OAuthClient
+	var authStates *stateStore
+	if cfg.IssuerURL != "" && cfg.ClientID != "" && cfg.RedirectURL != "" {
+		oauthClient, err = keycloak.NewOAuthClient(keycloak.OAuthConfig{
+			IssuerURL:   cfg.IssuerURL,
+			ClientID:    cfg.ClientID,
+			RedirectURL: cfg.RedirectURL,
+			Scopes:      cfg.Scopes,
+			HTTPClient:  &http.Client{Timeout: 5 * time.Second},
+		})
+		if err != nil {
+			logger.Printf("keycloak oauth disabled: %v", err)
+		} else {
+			authStates = newStateStore(authStateTTL)
+			logger.Printf("keycloak oauth initialised; redirect URI %s", cfg.RedirectURL)
+		}
+	} else {
+		logger.Printf("keycloak oauth configuration missing; /keycloak/login disabled")
+	}
+
+	srv := &service{logger: logger, tokenVerifier: verifier, oauthClient: oauthClient, authStates: authStates}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", srv.handleIndex)
 	mux.HandleFunc("/healthz", srv.handleHealthz)
 	mux.HandleFunc("/secure-data", srv.handleSecureData)
 	mux.HandleFunc("/keycloak-data", srv.handleKeycloakData)
+	mux.HandleFunc("/keycloak/login", srv.handleKeycloakLogin)
+	mux.HandleFunc("/keycloak/callback", srv.handleKeycloakCallback)
 
 	port := strings.TrimSpace(os.Getenv("PORT"))
 	if port == "" {
@@ -81,11 +132,18 @@ func loadKeycloakConfig() keycloakConfig {
 		jwksURL = strings.TrimSuffix(issuer, "/") + "/protocol/openid-connect/certs"
 	}
 
+	scopes := parseScopeList(os.Getenv("KEYCLOAK_SCOPES"))
+	if len(scopes) == 0 {
+		scopes = []string{"openid", "profile", "email"}
+	}
+
 	return keycloakConfig{
 		IssuerURL:     issuer,
 		ClientID:      strings.TrimSpace(os.Getenv("KEYCLOAK_CLIENT_ID")),
 		JWKSURL:       jwksURL,
 		IssuerAliases: parseEnvList(os.Getenv("KEYCLOAK_ISSUER_ALIASES")),
+		RedirectURL:   strings.TrimSpace(os.Getenv("KEYCLOAK_REDIRECT_URL")),
+		Scopes:        scopes,
 	}
 }
 
@@ -107,6 +165,36 @@ func parseEnvList(raw string) []string {
 		return nil
 	}
 	return values
+}
+
+func parseScopeList(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		switch r {
+		case ',', ' ', '\t':
+			return true
+		default:
+			return false
+		}
+	})
+
+	scopes := make([]string, 0, len(fields))
+	for _, scope := range fields {
+		trimmed := strings.TrimSpace(scope)
+		if trimmed != "" {
+			scopes = append(scopes, trimmed)
+		}
+	}
+
+	if len(scopes) == 0 {
+		return nil
+	}
+
+	return scopes
 }
 
 func buildKeycloakVerifier(ctx context.Context, cfg keycloakConfig) (*keycloak.Verifier, error) {
@@ -248,6 +336,105 @@ func (s *service) handleKeycloakData(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, resp, http.StatusOK)
 }
 
+func (s *service) handleKeycloakLogin(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if s.oauthClient == nil || s.authStates == nil {
+		http.Error(w, "keycloak oauth not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	state, err := generateState()
+	if err != nil {
+		s.logger.Printf("failed to generate oauth state: %v", err)
+		http.Error(w, "failed to initiate login", http.StatusInternalServerError)
+		return
+	}
+
+	codeVerifier, err := generateCodeVerifier()
+	if err != nil {
+		s.logger.Printf("failed to generate code verifier: %v", err)
+		http.Error(w, "failed to initiate login", http.StatusInternalServerError)
+		return
+	}
+
+	codeChallenge := codeChallengeFromVerifier(codeVerifier)
+
+	authURL, err := s.oauthClient.AuthCodeURL(state, codeChallenge)
+	if err != nil {
+		s.logger.Printf("failed to build auth URL: %v", err)
+		http.Error(w, "failed to initiate login", http.StatusInternalServerError)
+		return
+	}
+
+	s.authStates.store(state, codeVerifier)
+	s.logger.Printf("redirecting browser to Keycloak auth endpoint")
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+func (s *service) handleKeycloakCallback(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if s.oauthClient == nil || s.authStates == nil {
+		http.Error(w, "keycloak oauth not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	state := strings.TrimSpace(r.URL.Query().Get("state"))
+	code := strings.TrimSpace(r.URL.Query().Get("code"))
+	if state == "" || code == "" {
+		http.Error(w, "state and code are required", http.StatusBadRequest)
+		return
+	}
+
+	codeVerifier, ok := s.authStates.consume(state)
+	if !ok {
+		http.Error(w, "invalid or expired state", http.StatusBadRequest)
+		return
+	}
+
+	tokenResp, err := s.oauthClient.Exchange(r.Context(), code, codeVerifier)
+	if err != nil {
+		s.logger.Printf("token exchange failed: %v", err)
+		http.Error(w, "failed to exchange code", http.StatusBadGateway)
+		return
+	}
+
+	response := keycloakAuthResponse{
+		Service:      "service2",
+		Message:      "authorization code exchanged successfully",
+		AccessToken:  tokenResp.AccessToken,
+		IDToken:      tokenResp.IDToken,
+		RefreshToken: tokenResp.RefreshToken,
+		TokenType:    tokenResp.TokenType,
+		Scope:        tokenResp.Scope,
+		ExpiresIn:    tokenResp.ExpiresIn,
+	}
+
+	if s.tokenVerifier != nil && tokenResp.AccessToken != "" {
+		if claims, err := s.tokenVerifier.VerifyToken(r.Context(), tokenResp.AccessToken); err != nil {
+			s.logger.Printf("access token verification failed: %v", err)
+		} else {
+			response.AccessTokenDetails = &tokenClaims{
+				Subject:           claims.Subject,
+				PreferredUsername: claims.PreferredUsername,
+				Audience:          []string(claims.Audience),
+				Issuer:            claims.Issuer,
+				IssuedAt:          formatUnixTime(claims.IssuedAt),
+				ExpiresAt:         formatUnixTime(claims.Expiry),
+			}
+		}
+	}
+
+	writeJSON(w, response, http.StatusOK)
+}
+
 func writeJSON(w http.ResponseWriter, payload any, status int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -302,4 +489,82 @@ func (lrw *loggingResponseWriter) Write(p []byte) (int, error) {
 	n, err := lrw.ResponseWriter.Write(p)
 	lrw.bytesWritten += int64(n)
 	return n, err
+}
+
+const authStateTTL = 5 * time.Minute
+
+type stateStore struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	entries map[string]stateEntry
+}
+
+type stateEntry struct {
+	codeVerifier string
+	expiresAt    time.Time
+}
+
+func newStateStore(ttl time.Duration) *stateStore {
+	if ttl <= 0 {
+		ttl = authStateTTL
+	}
+	return &stateStore{
+		ttl:     ttl,
+		entries: make(map[string]stateEntry),
+	}
+}
+
+func (s *stateStore) store(state, codeVerifier string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.entries[state] = stateEntry{
+		codeVerifier: codeVerifier,
+		expiresAt:    time.Now().Add(s.ttl),
+	}
+}
+
+func (s *stateStore) consume(state string) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.entries[state]
+	if !ok {
+		return "", false
+	}
+	delete(s.entries, state)
+
+	if time.Now().After(entry.expiresAt) {
+		return "", false
+	}
+
+	return entry.codeVerifier, true
+}
+
+func generateCodeVerifier() (string, error) {
+	return randomString(32)
+}
+
+func generateState() (string, error) {
+	return randomString(24)
+}
+
+func randomString(bytes int) (string, error) {
+	buf := make([]byte, bytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("failed to read random bytes: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func codeChallengeFromVerifier(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func formatUnixTime(ts int64) string {
+	if ts == 0 {
+		return ""
+	}
+	return time.Unix(ts, 0).UTC().Format(time.RFC3339)
 }

--- a/internal/keycloak/oauth.go
+++ b/internal/keycloak/oauth.go
@@ -1,0 +1,140 @@
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// OAuthConfig contains the configuration values required to perform the
+// Authorization Code flow against a Keycloak realm.
+type OAuthConfig struct {
+	IssuerURL   string
+	ClientID    string
+	RedirectURL string
+	Scopes      []string
+	HTTPClient  *http.Client
+}
+
+// OAuthClient coordinates the Authorization Code flow for a Keycloak realm.
+type OAuthClient struct {
+	issuer      string
+	clientID    string
+	redirectURL string
+	scopes      []string
+	httpClient  *http.Client
+}
+
+// TokenResponse represents the JSON payload returned by the token endpoint.
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+	TokenType    string `json:"token_type"`
+	IDToken      string `json:"id_token"`
+}
+
+// NewOAuthClient returns an OAuthClient prepared for the provided configuration.
+func NewOAuthClient(cfg OAuthConfig) (*OAuthClient, error) {
+	issuer := normaliseIssuer(cfg.IssuerURL)
+	if issuer == "" {
+		return nil, errors.New("issuer URL must be provided")
+	}
+	clientID := strings.TrimSpace(cfg.ClientID)
+	if clientID == "" {
+		return nil, errors.New("client ID must be provided")
+	}
+	redirect := strings.TrimSpace(cfg.RedirectURL)
+	if redirect == "" {
+		return nil, errors.New("redirect URL must be provided")
+	}
+
+	scopes := cfg.Scopes
+	if len(scopes) == 0 {
+		scopes = []string{"openid"}
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+
+	return &OAuthClient{
+		issuer:      issuer,
+		clientID:    clientID,
+		redirectURL: redirect,
+		scopes:      scopes,
+		httpClient:  httpClient,
+	}, nil
+}
+
+// AuthCodeURL builds the authorization endpoint URL for the provided state and
+// PKCE code challenge.
+func (c *OAuthClient) AuthCodeURL(state, codeChallenge string) (string, error) {
+	if state = strings.TrimSpace(state); state == "" {
+		return "", errors.New("state must be provided")
+	}
+	if codeChallenge = strings.TrimSpace(codeChallenge); codeChallenge == "" {
+		return "", errors.New("code challenge must be provided")
+	}
+
+	endpoint := c.issuer + "/protocol/openid-connect/auth"
+
+	values := url.Values{}
+	values.Set("response_type", "code")
+	values.Set("client_id", c.clientID)
+	values.Set("redirect_uri", c.redirectURL)
+	values.Set("scope", strings.Join(c.scopes, " "))
+	values.Set("state", state)
+	values.Set("code_challenge", codeChallenge)
+	values.Set("code_challenge_method", "S256")
+
+	return endpoint + "?" + values.Encode(), nil
+}
+
+// Exchange swaps an authorisation code for tokens using the stored configuration.
+func (c *OAuthClient) Exchange(ctx context.Context, code, codeVerifier string) (TokenResponse, error) {
+	if code = strings.TrimSpace(code); code == "" {
+		return TokenResponse{}, errors.New("code must be provided")
+	}
+	if codeVerifier = strings.TrimSpace(codeVerifier); codeVerifier == "" {
+		return TokenResponse{}, errors.New("code verifier must be provided")
+	}
+
+	tokenEndpoint := c.issuer + "/protocol/openid-connect/token"
+
+	data := url.Values{}
+	data.Set("grant_type", "authorization_code")
+	data.Set("client_id", c.clientID)
+	data.Set("code", code)
+	data.Set("redirect_uri", c.redirectURL)
+	data.Set("code_verifier", codeVerifier)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return TokenResponse{}, fmt.Errorf("failed to create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return TokenResponse{}, fmt.Errorf("token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return TokenResponse{}, fmt.Errorf("token endpoint returned status %d", resp.StatusCode)
+	}
+
+	var tokenResp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return TokenResponse{}, fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	return tokenResp, nil
+}


### PR DESCRIPTION
## Summary
- add a reusable Keycloak OAuth client to drive the authorization code flow with PKCE
- expose /keycloak/login and /keycloak/callback handlers in both services to exchange codes for tokens and surface decoded claims
- document the new endpoints and configuration variables required to enable the interactive login flow

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dfb066f7248321ba824dec57d09e4f