### PR TITLE
Import Service2 users after successful authentication

### DIFF
--- a/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserAdapter.java
+++ b/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserAdapter.java
@@ -34,9 +34,9 @@ class S2UserAdapter extends AbstractUserAdapter.Streams {
         this.id = StorageId.keycloakId(model, username);
         this.credentialManager = new S2SubjectCredentialManager();
         attributes.put(UserModel.USERNAME, Collections.singletonList(username));
-        attributes.put(UserModel.EMAIL, Collections.singletonList(username + "@service2.local"));
-        attributes.put(UserModel.FIRST_NAME, Collections.singletonList("Service2"));
-        attributes.put(UserModel.LAST_NAME, Collections.singletonList("User"));
+        attributes.put(UserModel.EMAIL, Collections.singletonList(S2UserStorageProvider.defaultEmailFor(username)));
+        attributes.put(UserModel.FIRST_NAME, Collections.singletonList(S2UserStorageProvider.DEFAULT_FIRST_NAME));
+        attributes.put(UserModel.LAST_NAME, Collections.singletonList(S2UserStorageProvider.DEFAULT_LAST_NAME));
     }
 
     @Override

--- a/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProvider.java
+++ b/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProvider.java
@@ -15,6 +15,7 @@ import org.keycloak.component.ComponentModel;
 import org.keycloak.credential.CredentialInput;
 import org.keycloak.credential.CredentialInputValidator;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.storage.StorageId;
@@ -28,6 +29,9 @@ public class S2UserStorageProvider implements UserStorageProvider, UserLookupPro
 
     private static final Logger LOGGER = Logger.getLogger(S2UserStorageProvider.class);
     private static final String PASSWORD_CREDENTIAL_TYPE = "password";
+    static final String DEFAULT_FIRST_NAME = "Service2";
+    static final String DEFAULT_LAST_NAME = "User";
+    private static final String DEFAULT_EMAIL_DOMAIN = "@service2.local";
 
     private final KeycloakSession session;
     private final ComponentModel model;
@@ -101,7 +105,11 @@ public class S2UserStorageProvider implements UserStorageProvider, UserLookupPro
         if (password == null) {
             return false;
         }
-        return validateAgainstService(username, password);
+        boolean valid = validateAgainstService(username, password);
+        if (valid) {
+            importUserIfNeeded(realm, username);
+        }
+        return valid;
     }
 
     private UserModel createAdapter(RealmModel realm, String username) {
@@ -137,6 +145,24 @@ public class S2UserStorageProvider implements UserStorageProvider, UserLookupPro
             LOGGER.warnf(e, "Request interrupted while validating %s", username);
             return false;
         }
+    }
+
+    private void importUserIfNeeded(RealmModel realm, String username) {
+        LOGGER.debugf("Importing user %s into realm %s if necessary", username, realm.getName());
+        try {
+            UserModel user = session.users().addUser(realm, username);
+            user.setEnabled(true);
+            user.setEmail(defaultEmailFor(username));
+            user.setFirstName(DEFAULT_FIRST_NAME);
+            user.setLastName(DEFAULT_LAST_NAME);
+            user.setFederationLink(model.getId());
+        } catch (ModelDuplicateException duplicate) {
+            LOGGER.debugf("User %s already exists locally, skipping import", username);
+        }
+    }
+
+    static String defaultEmailFor(String username) {
+        return username + DEFAULT_EMAIL_DOMAIN;
     }
 
     private static String buildBasicAuth(String username, String password) {


### PR DESCRIPTION
## Summary
- ensure the Service2 user storage provider imports users into the realm after successful authentication
- add shared defaults for generated profile information to keep the adapter and importer consistent

## Testing
- mvn -f keycloak/user-storage-s2/pom.xml -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e41fb565988321862e88707ddf43cb