### PR TITLE
Import Service2 users after successful auth

### DIFF
--- a/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProvider.java
+++ b/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProvider.java
@@ -101,7 +101,11 @@ public class S2UserStorageProvider implements UserStorageProvider, UserLookupPro
         if (password == null) {
             return false;
         }
-        return validateAgainstService(username, password);
+        boolean valid = validateAgainstService(username, password);
+        if (valid) {
+            ensureUserImported(realm, username);
+        }
+        return valid;
     }
 
     private UserModel createAdapter(RealmModel realm, String username) {
@@ -143,5 +147,19 @@ public class S2UserStorageProvider implements UserStorageProvider, UserLookupPro
         String token = username + ":" + password;
         String encoded = Base64.getEncoder().encodeToString(token.getBytes(StandardCharsets.UTF_8));
         return "Basic " + encoded;
+    }
+
+    private void ensureUserImported(RealmModel realm, String username) {
+        UserModel existing = session.userLocalStorage().getUserByUsername(realm, username);
+        if (existing != null) {
+            return;
+        }
+
+        UserModel imported = session.userLocalStorage().addUser(realm, username);
+        imported.setEnabled(true);
+        imported.setEmail(username + "@service2.local");
+        imported.setFirstName("Service2");
+        imported.setLastName("User");
+        imported.setFederationLink(model.getId());
     }
 }


### PR DESCRIPTION
## Summary
- ensure Service2 users are imported into Keycloak local storage after successful authentication
- populate basic profile information and link the imported user to the storage provider

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e41fb565988321862e88707ddf43cb