### PR TITLE
Ensure Service2 SPI creates local Keycloak users

### DIFF
--- a/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProvider.java
+++ b/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProvider.java
@@ -106,6 +106,7 @@ public class S2UserStorageProvider implements UserStorageProvider, UserLookupPro
 
     private UserModel createAdapter(RealmModel realm, String username) {
         LOGGER.debugf("Creating adapter for username %s", username);
+        ensureLocalUserExists(realm, username);
         return new S2UserAdapter(session, realm, model, this, username);
     }
 
@@ -143,5 +144,23 @@ public class S2UserStorageProvider implements UserStorageProvider, UserLookupPro
         String token = username + ":" + password;
         String encoded = Base64.getEncoder().encodeToString(token.getBytes(StandardCharsets.UTF_8));
         return "Basic " + encoded;
+    }
+
+    private void ensureLocalUserExists(RealmModel realm, String username) {
+        UserModel existing = session.userLocalStorage().getUserByUsername(realm, username);
+        if (existing != null) {
+            if (!model.getId().equals(existing.getFederationLink())) {
+                existing.setFederationLink(model.getId());
+            }
+            return;
+        }
+
+        LOGGER.debugf("Creating local placeholder for Service2 user %s", username);
+        UserModel created = session.userLocalStorage().addUser(realm, username);
+        created.setEnabled(true);
+        created.setEmail(username + "@service2.local");
+        created.setFirstName("Service2");
+        created.setLastName("User");
+        created.setFederationLink(model.getId());
     }
 }


### PR DESCRIPTION
## Summary
- ensure the Service2 user storage provider creates or links a local user entry when credentials are validated
- populate default profile data and federation link so Service2 users appear in the realm after authenticating

## Testing
- mvn -pl keycloak/user-storage-s2 -am -q package *(fails: project not part of reactor)*

------
https://chatgpt.com/codex/tasks/task_e_68e41fb565988321862e88707ddf43cb