### PR TITLE
Update Keycloak user storage provider for Jira auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,30 +165,29 @@ export KEYCLOAK_CLIENT_ID=service-client
 
 ### User Storage SPI example
 
-The Keycloak container image now bundles a custom **User Storage SPI** provider that delegates password checks to Service2's
-Basic Auth endpoint. The provider is packaged from the Maven project under `keycloak/user-storage-s2` and copied into Keycloak
-at build time.
+The Keycloak container image now bundles a custom **User Storage SPI** provider that validates credentials against a
+standalone Jira installation. The provider is packaged from the Maven project under `keycloak/user-storage-s2` and copied into
+Keycloak at build time.
 
-When the realm import runs, a new component named **Service2 Basic Auth** is created. The component accepts three configuration
+When the realm import runs, a new component named **Jira Auth** is created. The component accepts three configuration
 properties:
 
 | Property | Description | Default |
 | --- | --- | --- |
-| `s2BaseUrl` | Base URL used to contact Service2. | `http://service2:8081` |
-| `s2Endpoint` | Relative path of the Basic Auth protected endpoint. | `/secure-data` |
-| `s2TimeoutMillis` | Timeout (in milliseconds) for validation requests. | `2000` |
+| `jiraBaseUrl` | Base URL used to contact Jira. | `http://jira:8080` |
+| `jiraAuthEndpoint` | Relative path of the Jira authentication endpoint. | `/rest/auth/1/session` |
+| `jiraTimeoutMillis` | Timeout (in milliseconds) for validation requests. | `2000` |
 
 To test the integration locally:
 
-1. Start Service2 so it is reachable by Keycloak. When running Keycloak via Docker, place both containers on the same network
-   and keep Service2 available as `http://service2:8081` or adjust the component configuration in the Keycloak admin console.
+1. Ensure Jira is reachable by Keycloak. When running Keycloak via Docker, place both containers on the same network and keep
+   Jira available as `http://jira:8080` (or adjust the component configuration in the Keycloak admin console).
 2. Build and run the Keycloak image with `docker build -f Dockerfile.keycloak -t demo-keycloak .` followed by
    `docker run --rm -p 8080:8080 --name keycloak demo-keycloak`.
-3. Authenticate against Keycloak with the Service2 Basic Auth credentials, e.g. obtain a token using
-   `demo-user` / `demo-pass` as the username and password.
+3. Authenticate against Keycloak with the Jira credentials you expect to be valid.
 
-During authentication Keycloak issues a Basic Auth request to Service2's secure endpoint. A `200 OK` response marks the
-credentials as valid while other responses (or timeouts) reject the login attempt.
+During authentication Keycloak issues a POST request to Jira's auth endpoint with the provided username and password in the
+request body. A `200 OK` response marks the credentials as valid while other responses (or timeouts) reject the login attempt.
 
 The JWKS endpoint is automatically derived from the issuer but can be overridden via `KEYCLOAK_JWKS_URL` if required.
 

--- a/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserAdapter.java
+++ b/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserAdapter.java
@@ -17,7 +17,7 @@ import org.keycloak.storage.StorageId;
 import org.keycloak.storage.adapter.AbstractUserAdapter;
 
 /**
- * Minimal user adapter that exposes Service2 users to Keycloak.
+ * Minimal user adapter that exposes Jira users to Keycloak.
  */
 class S2UserAdapter extends AbstractUserAdapter.Streams {
 

--- a/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProvider.java
+++ b/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProvider.java
@@ -7,7 +7,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Base64;
 import java.util.Objects;
 
 import org.jboss.logging.Logger;
@@ -23,26 +22,26 @@ import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.user.UserLookupProvider;
 
 /**
- * Delegates password validation to Service2 by issuing a Basic Auth request against its secure endpoint.
+ * Delegates password validation to a standalone Jira installation by invoking its authentication endpoint.
  */
 public class S2UserStorageProvider implements UserStorageProvider, UserLookupProvider, CredentialInputValidator {
 
     private static final Logger LOGGER = Logger.getLogger(S2UserStorageProvider.class);
     private static final String PASSWORD_CREDENTIAL_TYPE = "password";
-    static final String DEFAULT_FIRST_NAME = "Service2";
+    static final String DEFAULT_FIRST_NAME = "Jira";
     static final String DEFAULT_LAST_NAME = "User";
-    private static final String DEFAULT_EMAIL_DOMAIN = "@service2.local";
+    private static final String DEFAULT_EMAIL_DOMAIN = "@jira.local";
 
     private final KeycloakSession session;
     private final ComponentModel model;
     private final HttpClient httpClient;
-    private final URI secureEndpoint;
+    private final URI authEndpoint;
     private final Duration timeout;
 
-    public S2UserStorageProvider(KeycloakSession session, ComponentModel model, URI secureEndpoint, Duration timeout) {
+    public S2UserStorageProvider(KeycloakSession session, ComponentModel model, URI authEndpoint, Duration timeout) {
         this.session = session;
         this.model = model;
-        this.secureEndpoint = secureEndpoint;
+        this.authEndpoint = authEndpoint;
         this.timeout = timeout;
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(timeout)
@@ -105,7 +104,7 @@ public class S2UserStorageProvider implements UserStorageProvider, UserLookupPro
         if (password == null) {
             return false;
         }
-        boolean valid = validateAgainstService(username, password);
+        boolean valid = validateAgainstJira(username, password);
         if (valid) {
             importUserIfNeeded(realm, username);
         }
@@ -117,28 +116,30 @@ public class S2UserStorageProvider implements UserStorageProvider, UserLookupPro
         return new S2UserAdapter(session, realm, model, this, username);
     }
 
-    private boolean validateAgainstService(String username, String password) {
-        LOGGER.debugf("Validating credentials for %s using Service2", username);
-        HttpRequest request = HttpRequest.newBuilder(secureEndpoint)
+    private boolean validateAgainstJira(String username, String password) {
+        LOGGER.debugf("Validating credentials for %s using Jira", username);
+
+        String payload = toAuthPayload(username, password);
+        HttpRequest request = HttpRequest.newBuilder(authEndpoint)
                 .timeout(timeout)
-                .header("Authorization", buildBasicAuth(username, password))
-                .GET()
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
                 .build();
         try {
             HttpResponse<Void> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
             int status = response.statusCode();
             if (status == 200) {
-                LOGGER.debugf("Service2 accepted credentials for %s", username);
+                LOGGER.debugf("Jira accepted credentials for %s", username);
                 return true;
             }
             if (status == 401) {
-                LOGGER.debugf("Service2 rejected credentials for %s", username);
+                LOGGER.debugf("Jira rejected credentials for %s", username);
                 return false;
             }
-            LOGGER.warnf("Unexpected status %d while validating %s via Service2", status, username);
+            LOGGER.warnf("Unexpected status %d while validating %s via Jira", status, username);
             return false;
         } catch (IOException e) {
-            LOGGER.errorf(e, "IO error while validating %s against Service2", username);
+            LOGGER.errorf(e, "IO error while validating %s against Jira", username);
             return false;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -165,9 +166,17 @@ public class S2UserStorageProvider implements UserStorageProvider, UserLookupPro
         return username + DEFAULT_EMAIL_DOMAIN;
     }
 
-    private static String buildBasicAuth(String username, String password) {
-        String token = username + ":" + password;
-        String encoded = Base64.getEncoder().encodeToString(token.getBytes(StandardCharsets.UTF_8));
-        return "Basic " + encoded;
+    private static String toAuthPayload(String username, String password) {
+        String escapedUser = escapeJson(username);
+        String escapedPassword = escapeJson(password);
+        return String.format("{\"username\":\"%s\",\"password\":\"%s\"}", escapedUser, escapedPassword);
+    }
+
+    private static String escapeJson(String value) {
+        return value
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r");
     }
 }

--- a/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProviderFactory.java
+++ b/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProviderFactory.java
@@ -19,32 +19,32 @@ public class S2UserStorageProviderFactory implements UserStorageProviderFactory<
 
     public static final String PROVIDER_ID = "s2-user-storage";
 
-    static final String CONFIG_BASE_URL = "s2BaseUrl";
-    static final String CONFIG_ENDPOINT = "s2Endpoint";
-    static final String CONFIG_TIMEOUT = "s2TimeoutMillis";
+    static final String CONFIG_BASE_URL = "jiraBaseUrl";
+    static final String CONFIG_ENDPOINT = "jiraAuthEndpoint";
+    static final String CONFIG_TIMEOUT = "jiraTimeoutMillis";
 
     private static final Logger LOGGER = Logger.getLogger(S2UserStorageProviderFactory.class);
 
     private static final ProviderConfigProperty BASE_URL = new ProviderConfigProperty(
             CONFIG_BASE_URL,
-            "Service base URL",
-            "Base URL for Service2. The provider calls its Basic Auth endpoint to validate credentials.",
+            "Jira base URL",
+            "Base URL for the standalone Jira instance. The provider calls the authentication endpoint to validate credentials.",
             ProviderConfigProperty.STRING_TYPE,
-            "http://service2:8081"
+            "http://jira:8080"
     );
 
     private static final ProviderConfigProperty ENDPOINT = new ProviderConfigProperty(
             CONFIG_ENDPOINT,
-            "Secure endpoint path",
-            "Relative path that requires HTTP Basic authentication on Service2.",
+            "Authentication endpoint path",
+            "Relative path of the Jira authentication endpoint used to validate credentials.",
             ProviderConfigProperty.STRING_TYPE,
-            "/secure-data"
+            "/rest/auth/1/session"
     );
 
     private static final ProviderConfigProperty TIMEOUT = new ProviderConfigProperty(
             CONFIG_TIMEOUT,
             "Request timeout (ms)",
-            "Timeout in milliseconds when contacting Service2.",
+            "Timeout in milliseconds when contacting Jira.",
             ProviderConfigProperty.STRING_TYPE,
             "2000"
     );
@@ -58,7 +58,7 @@ public class S2UserStorageProviderFactory implements UserStorageProviderFactory<
         URI targetEndpoint = resolveEndpoint(baseUrl, endpoint);
         Duration timeout = parseTimeout(timeoutRaw);
 
-        LOGGER.debugf("Creating S2 user storage provider with endpoint %s and timeout %s", targetEndpoint, timeout);
+        LOGGER.debugf("Creating Jira user storage provider with endpoint %s and timeout %s", targetEndpoint, timeout);
         return new S2UserStorageProvider(session, model, targetEndpoint, timeout);
     }
 
@@ -93,7 +93,7 @@ public class S2UserStorageProviderFactory implements UserStorageProviderFactory<
             URI baseUri = new URI(effectiveBase);
             return baseUri.resolve(normalisedEndpoint);
         } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("Invalid Service2 URL configuration", e);
+            throw new IllegalArgumentException("Invalid Jira URL configuration", e);
         }
     }
 


### PR DESCRIPTION
## Summary
- update the Keycloak user storage SPI to call Jira's authentication endpoint when validating credentials
- rename provider configuration to Jira-specific defaults and refresh the user adapter metadata
- document the Jira-backed authentication flow in the README

## Testing
- not run (go test ./... hung while waiting for dependency resolution)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694312d97a74832187b324d4a6542884)