### PR TITLE
Make Keycloak SPI defaults configurable via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ properties:
 | `jiraAuthEndpoint` | Relative path of the Jira authentication endpoint. | `/rest/auth/1/session` |
 | `jiraTimeoutMillis` | Timeout (in milliseconds) for validation requests. | `2000` |
 
+When running the bundled Docker Compose stack, you can override the defaults through environment variables on the Keycloak
+container:
+
+- `S2_JIRA_BASE_URL` — default value for the `jiraBaseUrl` property (used if the component field is left blank).
+- `S2_JIRA_AUTH_ENDPOINT` — default value for the `jiraAuthEndpoint` property.
+- `S2_DEFAULT_EMAIL_DOMAIN` — suffix applied to imported Jira users when their email address is created (e.g. `@jira.local`).
+
 To test the integration locally:
 
 1. Ensure Jira is reachable by Keycloak. When running Keycloak via Docker, place both containers on the same network and keep

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
   keycloak:
     environment:
       - KC_LOG_LEVEL=INFO,com.example.keycloak.s2:DEBUG
+      - S2_JIRA_BASE_URL=http://jira:8080
+      - S2_JIRA_AUTH_ENDPOINT=/rest/auth/1/session
+      - S2_DEFAULT_EMAIL_DOMAIN=@jira.local
     build:
       context: .
       dockerfile: Dockerfile.keycloak

--- a/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProvider.java
+++ b/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProvider.java
@@ -38,7 +38,8 @@ public class S2UserStorageProvider implements UserStorageProvider, UserLookupPro
     private static final String PASSWORD_CREDENTIAL_TYPE = "password";
     static final String DEFAULT_FIRST_NAME = "Jira";
     static final String DEFAULT_LAST_NAME = "User";
-    private static final String DEFAULT_EMAIL_DOMAIN = "@jira.local";
+    private static final String DEFAULT_EMAIL_DOMAIN =
+            envOrDefault("S2_DEFAULT_EMAIL_DOMAIN", "@jira.local");
 
     private final KeycloakSession session;
     private final ComponentModel model;
@@ -225,5 +226,15 @@ public class S2UserStorageProvider implements UserStorageProvider, UserLookupPro
                 .replace("\"", "\\\"")
                 .replace("\n", "\\n")
                 .replace("\r", "\\r");
+    }
+
+    private static String envOrDefault(String envKey, String defaultValue) {
+        String value = System.getenv(envKey);
+        if (value == null) {
+            return defaultValue;
+        }
+
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? defaultValue : trimmed;
     }
 }

--- a/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProviderFactory.java
+++ b/keycloak/user-storage-s2/src/main/java/com/example/keycloak/s2/S2UserStorageProviderFactory.java
@@ -25,12 +25,15 @@ public class S2UserStorageProviderFactory implements UserStorageProviderFactory<
 
     private static final Logger LOGGER = Logger.getLogger(S2UserStorageProviderFactory.class);
 
+    private static final String DEFAULT_BASE_URL = envOrDefault("S2_JIRA_BASE_URL", "http://jira:8080");
+    private static final String DEFAULT_ENDPOINT = envOrDefault("S2_JIRA_AUTH_ENDPOINT", "/rest/auth/1/session");
+
     private static final ProviderConfigProperty BASE_URL = new ProviderConfigProperty(
             CONFIG_BASE_URL,
             "Jira base URL",
             "Base URL for the standalone Jira instance. The provider calls the authentication endpoint to validate credentials.",
             ProviderConfigProperty.STRING_TYPE,
-            "http://jira:8080"
+            DEFAULT_BASE_URL
     );
 
     private static final ProviderConfigProperty ENDPOINT = new ProviderConfigProperty(
@@ -38,7 +41,7 @@ public class S2UserStorageProviderFactory implements UserStorageProviderFactory<
             "Authentication endpoint path",
             "Relative path of the Jira authentication endpoint used to validate credentials.",
             ProviderConfigProperty.STRING_TYPE,
-            "/rest/auth/1/session"
+            DEFAULT_ENDPOINT
     );
 
     private static final ProviderConfigProperty TIMEOUT = new ProviderConfigProperty(
@@ -117,5 +120,15 @@ public class S2UserStorageProviderFactory implements UserStorageProviderFactory<
     private static String defaultValue(ProviderConfigProperty property) {
         Object value = property.getDefaultValue();
         return value != null ? value.toString() : "";
+    }
+
+    private static String envOrDefault(String envKey, String defaultValue) {
+        String value = System.getenv(envKey);
+        if (value == null) {
+            return defaultValue;
+        }
+
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? defaultValue : trimmed;
     }
 }


### PR DESCRIPTION
## Summary
- allow overriding the default email domain for imported users via env var
- source Jira base URL and auth endpoint defaults for the SPI from environment variables
- document new environment variables and add them to the docker compose stack

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943e728b97c83219d85a0f05b88cea7)